### PR TITLE
Fix missing Microsoft.Extensions dependencies

### DIFF
--- a/AgentRule.md
+++ b/AgentRule.md
@@ -8,6 +8,16 @@
 
 ## 0) Mục tiêu, Phạm vi, Không-mục tiêu
 
+### Quy trình Git để tránh conflict
+
+- **Luôn làm việc trên nhánh `main`**: trước khi bắt đầu, kiểm tra `git status -sb` và chắc chắn `## main` đang sạch.
+- **Đồng bộ mã nguồn mới nhất**: chạy `git fetch --all` rồi `git pull --rebase` (hoặc `git pull origin main --rebase` nếu đã cấu hình remote). Không commit khi chưa cập nhật với remote.
+- **Commits gọn và mạch lạc**: gom các thay đổi có liên quan vào cùng một commit, tránh sửa file thừa gây xung đột.
+- **Kiểm tra trước khi commit**: `git status` để đảm bảo chỉ các file cần thiết được thay đổi, xoá file rác hoặc cache.
+- **Không tạo nhánh phụ**: tất cả thay đổi phải được commit trực tiếp lên `main` theo yêu cầu khách hàng.
+
+> Nếu phát hiện conflict, quay lại bước đồng bộ (`git pull --rebase`) rồi sửa trước khi commit.
+
 **Mục tiêu**
 - Web app on‑prem (ASP.NET Core **.NET 9**) + **SQLite**.
 - Hai khu vực chức năng:

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,8 @@
+<Project>
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,59 @@
-# OCR
+# OCR Suite (.NET 9 POC)
+
+Hệ thống OCR on-prem hỗ trợ hai chế độ **FAST (Tesseract)** và **ENHANCED (PP-OCR ONNX)** theo hướng dẫn trong `AgentRule.md`.
+
+## Cấu trúc thư mục
+
+```
+.
+├── src/
+│   ├── Ocr.Api/           # ASP.NET Core Minimal API + Test UI
+│   ├── Ocr.Core/          # Domain models, abstractions, coordinator
+│   ├── Ocr.Storage/       # EF Core (SQLite) context + seed
+│   ├── Ocr.Preprocess/    # Image preprocessors (Fast/Enhanced)
+│   ├── Ocr.Engines/       # Engine factory + Tesseract & PP-OCR wrappers
+│   ├── Ocr.Extractor/     # Regex-based extractor + sampler provider
+│   ├── Ocr.Classifier/    # Stub ML.NET classifier loader
+│   └── Ocr.Workers/       # Background workers (engine warmup)
+├── templates/             # Template + sampler cấu hình JSON
+├── models/                # Thư mục chứa tessdata và ONNX (copy thủ công)
+├── data/                  # CSDL SQLite (runtime)
+├── uploads/               # Tệp upload/labeled
+└── scripts/               # Helper scripts (để trống)
+```
+
+## Thiết lập
+
+1. Cài [.NET 9 SDK preview](https://dotnet.microsoft.com/).
+2. Tạo thư mục model & DB:
+   ```bash
+   mkdir -p models/tessdata models/onnx data uploads templates
+   ```
+3. Copy `vie.traineddata`, `eng.traineddata` vào `models/tessdata/`.
+4. Copy `ppocrv3_det.onnx`, `ppocrv3_rec.onnx`, `dict.txt` vào `models/onnx/`.
+5. Khởi tạo SQLite (file tự tạo khi chạy lần đầu).
+
+## Chạy ứng dụng
+
+```bash
+dotnet restore
+dotnet build
+dotnet run --project src/Ocr.Api
+```
+
+Ứng dụng cung cấp:
+- **Swagger** tại `/swagger`.
+- **UI test nhanh** tại `/test` (upload ảnh, chọn mode/sampler, xem kết quả JSON).
+- **REST API** `/api/ocr` (multipart form: `file`, optional `docType`, `sampler`, `mode`).
+- **Admin API** `/api/admin/doc-types` (danh sách docType + template active).
+
+## Ghi chú
+
+- `OcrEngineFactory` tự động chọn FAST/ENHANCED theo `OcrMode` yêu cầu hoặc `PreferredMode` của `DocumentType`.
+- `SamplerProvider` tải cấu hình từ `templates/samplers.json`.
+- `SeedData` tạo sẵn docType `CCCD_FULL` với template regex mẫu.
+- Cần tối ưu hoá và tích hợp pipeline PP-OCR thực tế khi có model.
+
+## License
+
+MIT (tùy chỉnh theo nhu cầu).

--- a/ocr-suite.sln
+++ b/ocr-suite.sln
@@ -1,0 +1,63 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.0.0
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ocr.Api", "src/Ocr.Api/Ocr.Api.csproj", "{11111111-1111-1111-1111-111111111111}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ocr.Core", "src/Ocr.Core/Ocr.Core.csproj", "{22222222-2222-2222-2222-222222222222}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ocr.Storage", "src/Ocr.Storage/Ocr.Storage.csproj", "{33333333-3333-3333-3333-333333333333}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ocr.Preprocess", "src/Ocr.Preprocess/Ocr.Preprocess.csproj", "{44444444-4444-4444-4444-444444444444}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ocr.Engines", "src/Ocr.Engines/Ocr.Engines.csproj", "{55555555-5555-5555-5555-555555555555}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ocr.Extractor", "src/Ocr.Extractor/Ocr.Extractor.csproj", "{66666666-6666-6666-6666-666666666666}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ocr.Classifier", "src/Ocr.Classifier/Ocr.Classifier.csproj", "{77777777-7777-7777-7777-777777777777}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Ocr.Workers", "src/Ocr.Workers/Ocr.Workers.csproj", "{88888888-8888-8888-8888-888888888888}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{11111111-1111-1111-1111-111111111111}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{11111111-1111-1111-1111-111111111111}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{11111111-1111-1111-1111-111111111111}.Release|Any CPU.Build.0 = Release|Any CPU
+{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{22222222-2222-2222-2222-222222222222}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{22222222-2222-2222-2222-222222222222}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{22222222-2222-2222-2222-222222222222}.Release|Any CPU.Build.0 = Release|Any CPU
+{33333333-3333-3333-3333-333333333333}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{33333333-3333-3333-3333-333333333333}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{33333333-3333-3333-3333-333333333333}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{33333333-3333-3333-3333-333333333333}.Release|Any CPU.Build.0 = Release|Any CPU
+{44444444-4444-4444-4444-444444444444}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{44444444-4444-4444-4444-444444444444}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{44444444-4444-4444-4444-444444444444}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{44444444-4444-4444-4444-444444444444}.Release|Any CPU.Build.0 = Release|Any CPU
+{55555555-5555-5555-5555-555555555555}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{55555555-5555-5555-5555-555555555555}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{55555555-5555-5555-5555-555555555555}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{55555555-5555-5555-5555-555555555555}.Release|Any CPU.Build.0 = Release|Any CPU
+{66666666-6666-6666-6666-666666666666}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{66666666-6666-6666-6666-666666666666}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{66666666-6666-6666-6666-666666666666}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{66666666-6666-6666-6666-666666666666}.Release|Any CPU.Build.0 = Release|Any CPU
+{77777777-7777-7777-7777-777777777777}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{77777777-7777-7777-7777-777777777777}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{77777777-7777-7777-7777-777777777777}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{77777777-7777-7777-7777-777777777777}.Release|Any CPU.Build.0 = Release|Any CPU
+{88888888-8888-8888-8888-888888888888}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{88888888-8888-8888-8888-888888888888}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{88888888-8888-8888-8888-888888888888}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{88888888-8888-8888-8888-888888888888}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+GlobalSection(SolutionProperties) = preSolution
+HideSolutionNode = FALSE
+EndGlobalSection
+EndGlobal

--- a/src/Ocr.Api/Ocr.Api.csproj
+++ b/src/Ocr.Api/Ocr.Api.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <ItemGroup>
+    <ProjectReference Include="../Ocr.Core/Ocr.Core.csproj" />
+    <ProjectReference Include="../Ocr.Storage/Ocr.Storage.csproj" />
+    <ProjectReference Include="../Ocr.Preprocess/Ocr.Preprocess.csproj" />
+    <ProjectReference Include="../Ocr.Engines/Ocr.Engines.csproj" />
+    <ProjectReference Include="../Ocr.Extractor/Ocr.Extractor.csproj" />
+    <ProjectReference Include="../Ocr.Classifier/Ocr.Classifier.csproj" />
+    <ProjectReference Include="../Ocr.Workers/Ocr.Workers.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+  </ItemGroup>
+</Project>

--- a/src/Ocr.Api/Program.cs
+++ b/src/Ocr.Api/Program.cs
@@ -56,7 +56,7 @@ builder.Services.AddScoped<OcrCoordinator>(sp =>
         sp.GetRequiredService<IOcrEngineFactory>(),
         sp.GetRequiredService<ITemplateExtractor>(),
         sp.GetRequiredService<ISamplerProvider>(),
-        code => repository.FindByCodeAsync(code));
+        (code, token) => repository.FindByCodeAsync(code, token));
 });
 
 builder.Services.AddHostedService<EngineWarmupWorker>();

--- a/src/Ocr.Api/Program.cs
+++ b/src/Ocr.Api/Program.cs
@@ -1,0 +1,188 @@
+using System.Linq;
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Hosting;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.OpenApi.Models;
+using Ocr.Core;
+using Ocr.Core.Abstractions;
+using Ocr.Core.Models;
+using Ocr.Core.Options;
+using Ocr.Core.Services;
+using Ocr.Engines;
+using Ocr.Extractor;
+using Ocr.Preprocess;
+using Ocr.Storage;
+using Ocr.Workers;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddOptions();
+builder.Services.Configure<OcrOptions>(builder.Configuration.GetSection("Ocr"));
+
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseSqlite(builder.Configuration.GetConnectionString("Default")));
+
+builder.Services.AddScoped<DocumentTypeRepository>();
+
+builder.Services.AddSingleton<FastPreprocessor>();
+builder.Services.AddSingleton<EnhancedPreprocessor>();
+
+builder.Services.AddSingleton<RegexTemplateExtractor>();
+builder.Services.AddSingleton<SamplerProvider>(sp =>
+{
+    var provider = new SamplerProvider(sp.GetRequiredService<ILogger<SamplerProvider>>());
+    var env = sp.GetRequiredService<IHostEnvironment>();
+    var path = Path.Combine(env.ContentRootPath, "templates", "samplers.json");
+    if (File.Exists(path))
+    {
+        provider.LoadFromJson(File.ReadAllText(path));
+    }
+    return provider;
+});
+
+builder.Services.AddSingleton<ITemplateExtractor>(sp => sp.GetRequiredService<RegexTemplateExtractor>());
+builder.Services.AddSingleton<ISamplerProvider>(sp => sp.GetRequiredService<SamplerProvider>());
+
+builder.Services.AddSingleton<IOcrEngineFactory, Ocr.Engines.OcrEngineFactory>();
+
+builder.Services.AddScoped<OcrCoordinator>(sp =>
+{
+    var repository = sp.GetRequiredService<DocumentTypeRepository>();
+    return new OcrCoordinator(
+        sp.GetRequiredService<ILogger<OcrCoordinator>>(),
+        sp.GetRequiredService<IOcrEngineFactory>(),
+        sp.GetRequiredService<ITemplateExtractor>(),
+        sp.GetRequiredService<ISamplerProvider>(),
+        code => repository.FindByCodeAsync(code));
+});
+
+builder.Services.AddHostedService<EngineWarmupWorker>();
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen(options =>
+{
+    options.SwaggerDoc("v1", new OpenApiInfo
+    {
+        Title = "OCR Suite API",
+        Version = "v1"
+    });
+});
+
+var app = builder.Build();
+
+app.UseSwagger();
+app.UseSwaggerUI();
+
+using (var scope = app.Services.CreateScope())
+{
+    var dbContext = scope.ServiceProvider.GetRequiredService<AppDbContext>();
+    await SeedData.EnsureSeedDataAsync(dbContext);
+}
+
+app.MapGet("/", () => Results.Redirect("/test"));
+
+app.MapGet("/api/admin/doc-types", async (DocumentTypeRepository repository, CancellationToken cancellationToken) =>
+{
+    var docTypes = await repository.ListAsync(cancellationToken);
+    return Results.Ok(docTypes.Select(dt => new
+    {
+        dt.Id,
+        dt.Code,
+        dt.Name,
+        PreferredMode = dt.PreferredMode.ToString(),
+        Templates = dt.Templates.Select(t => new { t.Id, t.Version, t.IsActive })
+    }));
+});
+
+app.MapPost("/api/ocr", async Task<Results<Ok<OcrResult>, BadRequest<string>>> (
+    HttpRequest request,
+    OcrCoordinator coordinator,
+    CancellationToken cancellationToken) =>
+{
+    if (!request.HasFormContentType)
+    {
+        return TypedResults.BadRequest("Invalid form data");
+    }
+
+    var form = await request.ReadFormAsync(cancellationToken);
+    var file = form.Files.GetFile("file");
+    if (file is null)
+    {
+        return TypedResults.BadRequest("Missing file");
+    }
+
+    var mode = ParseMode(form["mode"].FirstOrDefault());
+    var docTypeCode = form["docType"].FirstOrDefault();
+    var sampler = form["sampler"].FirstOrDefault();
+
+    await using var stream = file.OpenReadStream();
+    var result = await coordinator.ProcessAsync(new OcrRequest(stream, file.FileName, docTypeCode, mode, sampler), cancellationToken);
+    return TypedResults.Ok(result);
+});
+
+app.MapGet("/test", () => Results.Content(@"<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\" />
+  <title>OCR Suite Test</title>
+  <style>
+    body { font-family: sans-serif; margin: 40px; }
+    label { display: block; margin-top: 12px; }
+    textarea { width: 100%; min-height: 160px; }
+  </style>
+</head>
+<body>
+  <h1>OCR Suite – Test UI</h1>
+  <form id=\"ocr-form\" enctype=\"multipart/form-data\">
+    <label>Chọn ảnh/PDF: <input type=\"file\" name=\"file\" required /></label>
+    <label>Mã loại tài liệu (tùy chọn): <input name=\"docType\" placeholder=\"VD: CCCD_FULL\" /></label>
+    <label>Sampler (tùy chọn): <input name=\"sampler\" placeholder=\"VD: CCCD_ID\" /></label>
+    <label>Chế độ OCR:
+      <select name=\"mode\">
+        <option value=\"AUTO\">Auto</option>
+        <option value=\"FAST\">Fast (Tesseract)</option>
+        <option value=\"ENHANCED\">Enhanced (ONNX)</option>
+      </select>
+    </label>
+    <button type=\"submit\">Nhận dạng</button>
+  </form>
+  <h2>Kết quả</h2>
+  <pre id=\"result\"></pre>
+  <script>
+    const form = document.getElementById('ocr-form');
+    const resultEl = document.getElementById('result');
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const data = new FormData(form);
+      resultEl.textContent = 'Đang xử lý...';
+      const response = await fetch('/api/ocr', { method: 'POST', body: data });
+      if (!response.ok) {
+        resultEl.textContent = 'Lỗi: ' + await response.text();
+        return;
+      }
+      const json = await response.json();
+      resultEl.textContent = JSON.stringify(json, null, 2);
+    });
+  </script>
+</body>
+</html>", "text/html"));
+
+app.Run();
+
+static OcrMode ParseMode(string? raw)
+{
+    if (string.IsNullOrWhiteSpace(raw))
+    {
+        return OcrMode.Auto;
+    }
+
+    return raw.ToUpperInvariant() switch
+    {
+        "FAST" => OcrMode.Fast,
+        "ENHANCED" => OcrMode.Enhanced,
+        _ => OcrMode.Auto
+    };
+}

--- a/src/Ocr.Api/appsettings.json
+++ b/src/Ocr.Api/appsettings.json
@@ -1,0 +1,28 @@
+{
+  "Ocr": {
+    "DefaultMode": "AUTO",
+    "Tesseract": {
+      "TessdataPath": "models/tessdata",
+      "Languages": "vie+eng",
+      "Psm": 6,
+      "Oem": 1,
+      "Whitelist": ""
+    },
+    "Onnx": {
+      "DetModel": "models/onnx/ppocrv3_det.onnx",
+      "RecModel": "models/onnx/ppocrv3_rec.onnx",
+      "Provider": "CPU",
+      "UseGpu": false,
+      "ThreadCount": 4
+    }
+  },
+  "ConnectionStrings": {
+    "Default": "Data Source=./data/ocr.sqlite"
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/src/Ocr.Classifier/Ocr.Classifier.csproj
+++ b/src/Ocr.Classifier/Ocr.Classifier.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.ML" Version="3.0.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Ocr.Core/Ocr.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Ocr.Classifier/TextClassifier.cs
+++ b/src/Ocr.Classifier/TextClassifier.cs
@@ -1,0 +1,91 @@
+namespace Ocr.Classifier;
+
+using System.IO;
+using System.Linq;
+using Microsoft.ML;
+using Microsoft.ML.Data;
+using Microsoft.Extensions.Logging;
+
+public sealed class TextClassifier
+{
+    private readonly ILogger<TextClassifier> _logger;
+    private readonly object _syncRoot = new();
+    private ITransformer? _model;
+    private PredictionEngine<TextSample, TextPrediction>? _predictionEngine;
+
+    public TextClassifier(ILogger<TextClassifier> logger)
+    {
+        _logger = logger;
+    }
+
+    public void LoadModel(string modelPath)
+    {
+        if (!File.Exists(modelPath))
+        {
+            _logger.LogWarning("Classifier model {Path} not found", modelPath);
+            return;
+        }
+
+        lock (_syncRoot)
+        {
+            var mlContext = new MLContext();
+            using var stream = File.OpenRead(modelPath);
+            _model = mlContext.Model.Load(stream, out _);
+            _predictionEngine = mlContext.Model.CreatePredictionEngine<TextSample, TextPrediction>(_model);
+        }
+    }
+
+    public string? Predict(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return null;
+        }
+
+        lock (_syncRoot)
+        {
+            if (_predictionEngine is null)
+            {
+                return null;
+            }
+
+            var prediction = _predictionEngine.Predict(new TextSample { Text = text });
+            if (prediction.Score is null || prediction.Score.Length == 0)
+            {
+                return null;
+            }
+
+            var maxIndex = 0;
+            for (var i = 1; i < prediction.Score.Length; i++)
+            {
+                if (prediction.Score[i] > prediction.Score[maxIndex])
+                {
+                    maxIndex = i;
+                }
+            }
+
+            if (_predictionEngine.OutputSchema.GetColumnOrNull("PredictedLabel")?.Column.GetAnnotationValue<VBuffer<ReadOnlyMemory<char>>>(AnnotationUtils.Kinds.SlotNames) is { } slotNames)
+            {
+                var names = slotNames.DenseValues().Select(memory => memory.ToString()).ToArray();
+                if (maxIndex < names.Length)
+                {
+                    return names[maxIndex];
+                }
+            }
+
+            return null;
+        }
+    }
+
+    private sealed class TextSample
+    {
+        [LoadColumn(0)]
+        public string Text { get; set; } = string.Empty;
+    }
+
+    private sealed class TextPrediction
+    {
+        [ColumnName("PredictedLabel")] public string PredictedLabel { get; set; } = string.Empty;
+        public float[]? Score { get; set; }
+    }
+}

--- a/src/Ocr.Core/Abstractions/IImagePreprocessor.cs
+++ b/src/Ocr.Core/Abstractions/IImagePreprocessor.cs
@@ -1,0 +1,10 @@
+namespace Ocr.Core.Abstractions;
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+public interface IImagePreprocessor
+{
+    Task<Stream> PreprocessAsync(Stream input, CancellationToken cancellationToken = default);
+}

--- a/src/Ocr.Core/Abstractions/IOcrEngine.cs
+++ b/src/Ocr.Core/Abstractions/IOcrEngine.cs
@@ -1,0 +1,12 @@
+namespace Ocr.Core.Abstractions;
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Ocr.Core.Models;
+
+public interface IOcrEngine
+{
+    string Name { get; }
+    Task<string> RecognizeTextAsync(Stream imageStream, CancellationToken cancellationToken = default);
+}

--- a/src/Ocr.Core/Abstractions/IOcrEngineFactory.cs
+++ b/src/Ocr.Core/Abstractions/IOcrEngineFactory.cs
@@ -1,0 +1,9 @@
+namespace Ocr.Core.Abstractions;
+
+using Ocr.Core;
+using Ocr.Core.Entities;
+
+public interface IOcrEngineFactory
+{
+    IOcrEngine GetEngine(OcrMode mode, DocumentType? documentType = null);
+}

--- a/src/Ocr.Core/Abstractions/ISamplerProvider.cs
+++ b/src/Ocr.Core/Abstractions/ISamplerProvider.cs
@@ -1,0 +1,8 @@
+namespace Ocr.Core.Abstractions;
+
+using System.Collections.Generic;
+
+public interface ISamplerProvider
+{
+    IReadOnlyDictionary<string, string> ApplySampler(IReadOnlyDictionary<string, string> fields, string? samplerCode);
+}

--- a/src/Ocr.Core/Abstractions/ITemplateExtractor.cs
+++ b/src/Ocr.Core/Abstractions/ITemplateExtractor.cs
@@ -1,0 +1,11 @@
+namespace Ocr.Core.Abstractions;
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Ocr.Core.Entities;
+
+public interface ITemplateExtractor
+{
+    Task<IReadOnlyDictionary<string, string>> ExtractAsync(string text, Template template, CancellationToken cancellationToken = default);
+}

--- a/src/Ocr.Core/Entities/DocumentSample.cs
+++ b/src/Ocr.Core/Entities/DocumentSample.cs
@@ -1,0 +1,17 @@
+namespace Ocr.Core.Entities;
+
+using System;
+
+public class DocumentSample
+{
+    public int Id { get; set; }
+    public int DocumentTypeId { get; set; }
+    public string FileName { get; set; } = string.Empty;
+    public string? FullText { get; set; }
+    public string? FieldsJson { get; set; }
+    public bool IsLabeled { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    public DocumentType? DocumentType { get; set; }
+}

--- a/src/Ocr.Core/Entities/DocumentType.cs
+++ b/src/Ocr.Core/Entities/DocumentType.cs
@@ -1,0 +1,22 @@
+namespace Ocr.Core.Entities;
+
+using System;
+using System.Collections.Generic;
+using Ocr.Core;
+
+public class DocumentType
+{
+    public int Id { get; set; }
+    public string Code { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? SchemaJson { get; set; }
+    public string? OcrConfigJson { get; set; }
+    public OcrMode PreferredMode { get; set; } = OcrMode.Auto;
+    public string? ModelPath { get; set; }
+    public string? OnnxConfigJson { get; set; }
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    public ICollection<Template> Templates { get; set; } = new List<Template>();
+    public ICollection<DocumentSample> Samples { get; set; } = new List<DocumentSample>();
+}

--- a/src/Ocr.Core/Entities/Template.cs
+++ b/src/Ocr.Core/Entities/Template.cs
@@ -1,0 +1,17 @@
+namespace Ocr.Core.Entities;
+
+using System;
+
+public class Template
+{
+    public int Id { get; set; }
+    public int DocumentTypeId { get; set; }
+    public string Version { get; set; } = "v1";
+    public string AnchorsJson { get; set; } = "{}";
+    public string FieldsJson { get; set; } = "{}";
+    public bool IsActive { get; set; } = true;
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    public DocumentType? DocumentType { get; set; }
+}

--- a/src/Ocr.Core/Models/OcrRequest.cs
+++ b/src/Ocr.Core/Models/OcrRequest.cs
@@ -1,0 +1,11 @@
+namespace Ocr.Core.Models;
+
+using System.IO;
+using Ocr.Core;
+
+public sealed record OcrRequest(
+    Stream Content,
+    string FileName,
+    string? DocumentTypeCode,
+    OcrMode Mode,
+    string? SamplerCode);

--- a/src/Ocr.Core/Models/OcrResult.cs
+++ b/src/Ocr.Core/Models/OcrResult.cs
@@ -1,12 +1,17 @@
 namespace Ocr.Core.Models;
 
 using System.Collections.Generic;
-using Ocr.Core.Entities;
-
+using System.Text.Json.Nodes;
 public sealed record OcrResult(
     string DocumentTypeCode,
     string Mode,
     string FullText,
     IReadOnlyDictionary<string, string> Fields,
-    IReadOnlyDictionary<string, string>? Metadata,
-    Template? TemplateUsed);
+    JsonObject? Metadata,
+    TemplateInfo? Template);
+
+public sealed record TemplateInfo(
+    int Id,
+    string Version,
+    string? AnchorsJson,
+    string? FieldsJson);

--- a/src/Ocr.Core/Models/OcrResult.cs
+++ b/src/Ocr.Core/Models/OcrResult.cs
@@ -1,0 +1,12 @@
+namespace Ocr.Core.Models;
+
+using System.Collections.Generic;
+using Ocr.Core.Entities;
+
+public sealed record OcrResult(
+    string DocumentTypeCode,
+    string Mode,
+    string FullText,
+    IReadOnlyDictionary<string, string> Fields,
+    IReadOnlyDictionary<string, string>? Metadata,
+    Template? TemplateUsed);

--- a/src/Ocr.Core/Ocr.Core.csproj
+++ b/src/Ocr.Core/Ocr.Core.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/Ocr.Core/OcrMode.cs
+++ b/src/Ocr.Core/OcrMode.cs
@@ -1,0 +1,8 @@
+namespace Ocr.Core;
+
+public enum OcrMode
+{
+    Auto,
+    Fast,
+    Enhanced
+}

--- a/src/Ocr.Core/Options/OcrOptions.cs
+++ b/src/Ocr.Core/Options/OcrOptions.cs
@@ -1,0 +1,28 @@
+namespace Ocr.Core.Options;
+
+using Ocr.Core;
+
+public sealed class OcrOptions
+{
+    public OcrMode DefaultMode { get; set; } = OcrMode.Auto;
+    public TesseractOptions Tesseract { get; set; } = new();
+    public OnnxOptions Onnx { get; set; } = new();
+}
+
+public sealed class TesseractOptions
+{
+    public string TessdataPath { get; set; } = "models/tessdata";
+    public string Languages { get; set; } = "vie+eng";
+    public int Psm { get; set; } = 6;
+    public int Oem { get; set; } = 1;
+    public string? Whitelist { get; set; }
+}
+
+public sealed class OnnxOptions
+{
+    public string DetModel { get; set; } = "models/onnx/ppocrv3_det.onnx";
+    public string RecModel { get; set; } = "models/onnx/ppocrv3_rec.onnx";
+    public string Provider { get; set; } = "CPU";
+    public bool UseGpu { get; set; }
+    public int ThreadCount { get; set; } = 4;
+}

--- a/src/Ocr.Core/Services/OcrCoordinator.cs
+++ b/src/Ocr.Core/Services/OcrCoordinator.cs
@@ -1,6 +1,8 @@
 namespace Ocr.Core.Services;
 
+using System.Collections.Generic;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -14,14 +16,14 @@ public sealed class OcrCoordinator
     private readonly IOcrEngineFactory _engineFactory;
     private readonly ITemplateExtractor _extractor;
     private readonly ISamplerProvider _samplerProvider;
-    private readonly Func<string, Task<DocumentType?>> _documentTypeResolver;
+    private readonly Func<string, CancellationToken, Task<DocumentType?>> _documentTypeResolver;
 
     public OcrCoordinator(
         ILogger<OcrCoordinator> logger,
         IOcrEngineFactory engineFactory,
         ITemplateExtractor extractor,
         ISamplerProvider samplerProvider,
-        Func<string, Task<DocumentType?>> documentTypeResolver)
+        Func<string, CancellationToken, Task<DocumentType?>> documentTypeResolver)
     {
         _logger = logger;
         _engineFactory = engineFactory;
@@ -37,13 +39,22 @@ public sealed class OcrCoordinator
         DocumentType? docType = null;
         if (!string.IsNullOrWhiteSpace(request.DocumentTypeCode))
         {
-            docType = await _documentTypeResolver(request.DocumentTypeCode!);
+            docType = await _documentTypeResolver(request.DocumentTypeCode!, cancellationToken);
+            if (docType is null)
+            {
+                _logger.LogWarning("Document type {DocType} not found; defaulting to AUTO mode", request.DocumentTypeCode);
+            }
         }
 
         var engine = _engineFactory.GetEngine(request.Mode, docType);
         _logger.LogInformation("Using engine {Engine}", engine.Name);
 
         await using var imageCopy = new MemoryStream();
+        if (request.Content.CanSeek)
+        {
+            request.Content.Position = 0;
+        }
+
         await request.Content.CopyToAsync(imageCopy, cancellationToken);
         imageCopy.Position = 0;
 
@@ -54,16 +65,36 @@ public sealed class OcrCoordinator
             ? await _extractor.ExtractAsync(text, template, cancellationToken)
             : new Dictionary<string, string>();
 
-        var filtered = _samplerProvider.ApplySampler(fields, request.SamplerCode);
+        var sampled = _samplerProvider.ApplySampler(fields, request.SamplerCode);
+        var filtered = sampled is Dictionary<string, string> dictionary
+            ? new Dictionary<string, string>(dictionary, StringComparer.OrdinalIgnoreCase)
+            : new Dictionary<string, string>(sampled, StringComparer.OrdinalIgnoreCase);
 
         _logger.LogInformation("OCR finished for {File}", request.FileName);
+
+        JsonObject? metadata = null;
+        if (!string.IsNullOrWhiteSpace(docType?.OcrConfigJson))
+        {
+            try
+            {
+                metadata = JsonNode.Parse(docType.OcrConfigJson!) as JsonObject;
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogWarning(ex, "Failed to deserialize OCR metadata for {DocType}", docType?.Code);
+            }
+        }
+
+        var templateInfo = template is null
+            ? null
+            : new TemplateInfo(template.Id, template.Version, template.AnchorsJson, template.FieldsJson);
 
         return new OcrResult(
             docType?.Code ?? "UNKNOWN",
             engine.Name,
             text,
             filtered,
-            docType?.OcrConfigJson is null ? null : JsonSerializer.Deserialize<Dictionary<string, string>>(docType.OcrConfigJson),
-            template);
+            metadata,
+            templateInfo);
     }
 }

--- a/src/Ocr.Core/Services/OcrCoordinator.cs
+++ b/src/Ocr.Core/Services/OcrCoordinator.cs
@@ -1,6 +1,8 @@
 namespace Ocr.Core.Services;
 
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading;

--- a/src/Ocr.Core/Services/OcrCoordinator.cs
+++ b/src/Ocr.Core/Services/OcrCoordinator.cs
@@ -1,0 +1,69 @@
+namespace Ocr.Core.Services;
+
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Ocr.Core.Abstractions;
+using Ocr.Core.Entities;
+using Ocr.Core.Models;
+
+public sealed class OcrCoordinator
+{
+    private readonly ILogger<OcrCoordinator> _logger;
+    private readonly IOcrEngineFactory _engineFactory;
+    private readonly ITemplateExtractor _extractor;
+    private readonly ISamplerProvider _samplerProvider;
+    private readonly Func<string, Task<DocumentType?>> _documentTypeResolver;
+
+    public OcrCoordinator(
+        ILogger<OcrCoordinator> logger,
+        IOcrEngineFactory engineFactory,
+        ITemplateExtractor extractor,
+        ISamplerProvider samplerProvider,
+        Func<string, Task<DocumentType?>> documentTypeResolver)
+    {
+        _logger = logger;
+        _engineFactory = engineFactory;
+        _extractor = extractor;
+        _samplerProvider = samplerProvider;
+        _documentTypeResolver = documentTypeResolver;
+    }
+
+    public async Task<OcrResult> ProcessAsync(OcrRequest request, CancellationToken cancellationToken = default)
+    {
+        _logger.LogInformation("Starting OCR for {File} in mode {Mode}", request.FileName, request.Mode);
+
+        DocumentType? docType = null;
+        if (!string.IsNullOrWhiteSpace(request.DocumentTypeCode))
+        {
+            docType = await _documentTypeResolver(request.DocumentTypeCode!);
+        }
+
+        var engine = _engineFactory.GetEngine(request.Mode, docType);
+        _logger.LogInformation("Using engine {Engine}", engine.Name);
+
+        await using var imageCopy = new MemoryStream();
+        await request.Content.CopyToAsync(imageCopy, cancellationToken);
+        imageCopy.Position = 0;
+
+        var text = await engine.RecognizeTextAsync(imageCopy, cancellationToken);
+
+        var template = docType?.Templates.FirstOrDefault(t => t.IsActive);
+        var fields = template is not null
+            ? await _extractor.ExtractAsync(text, template, cancellationToken)
+            : new Dictionary<string, string>();
+
+        var filtered = _samplerProvider.ApplySampler(fields, request.SamplerCode);
+
+        _logger.LogInformation("OCR finished for {File}", request.FileName);
+
+        return new OcrResult(
+            docType?.Code ?? "UNKNOWN",
+            engine.Name,
+            text,
+            filtered,
+            docType?.OcrConfigJson is null ? null : JsonSerializer.Deserialize<Dictionary<string, string>>(docType.OcrConfigJson),
+            template);
+    }
+}

--- a/src/Ocr.Engines/Ocr.Engines.csproj
+++ b/src/Ocr.Engines/Ocr.Engines.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+    <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.17.3" />
+    <PackageReference Include="Tesseract" Version="5.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Ocr.Core/Ocr.Core.csproj" />
+    <ProjectReference Include="../Ocr.Preprocess/Ocr.Preprocess.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Ocr.Engines/OcrEngineFactory.cs
+++ b/src/Ocr.Engines/OcrEngineFactory.cs
@@ -1,0 +1,135 @@
+namespace Ocr.Engines;
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.ML.OnnxRuntime;
+using Ocr.Core;
+using Ocr.Core.Abstractions;
+using Ocr.Core.Entities;
+using Ocr.Core.Options;
+using Ocr.Preprocess;
+
+public sealed class OcrEngineFactory : IOcrEngineFactory, IAsyncDisposable
+{
+    private readonly ILoggerFactory _loggerFactory;
+    private readonly IOptionsMonitor<OcrOptions> _options;
+    private readonly FastPreprocessor _fastPreprocessor;
+    private readonly EnhancedPreprocessor _enhancedPreprocessor;
+    private readonly Lazy<TesseractOcrEngine> _fastEngine;
+    private readonly Lazy<PpOcrOnnxEngine> _enhancedEngine;
+
+    public OcrEngineFactory(
+        ILoggerFactory loggerFactory,
+        IOptionsMonitor<OcrOptions> options,
+        FastPreprocessor fastPreprocessor,
+        EnhancedPreprocessor enhancedPreprocessor)
+    {
+        _loggerFactory = loggerFactory;
+        _options = options;
+        _fastPreprocessor = fastPreprocessor;
+        _enhancedPreprocessor = enhancedPreprocessor;
+        _fastEngine = new Lazy<TesseractOcrEngine>(CreateFastEngine, LazyThreadSafetyMode.ExecutionAndPublication);
+        _enhancedEngine = new Lazy<PpOcrOnnxEngine>(CreateEnhancedEngine, LazyThreadSafetyMode.ExecutionAndPublication);
+    }
+
+    public IOcrEngine GetEngine(OcrMode mode, DocumentType? documentType = null)
+    {
+        var effectiveMode = mode switch
+        {
+            OcrMode.Auto => documentType?.PreferredMode ?? _options.CurrentValue.DefaultMode,
+            _ => mode
+        };
+
+        return effectiveMode switch
+        {
+            OcrMode.Enhanced => TryGetEnhancedEngine() ?? _fastEngine.Value,
+            OcrMode.Fast => _fastEngine.Value,
+            _ => _fastEngine.Value
+        };
+    }
+
+    private TesseractOcrEngine CreateFastEngine()
+    {
+        var opts = _options.CurrentValue.Tesseract;
+        return new TesseractOcrEngine(
+            _loggerFactory.CreateLogger<TesseractOcrEngine>(),
+            _fastPreprocessor,
+            opts.TessdataPath,
+            opts.Languages,
+            opts.Psm,
+            opts.Oem,
+            opts.Whitelist);
+    }
+
+    private PpOcrOnnxEngine CreateEnhancedEngine()
+    {
+        var opts = _options.CurrentValue.Onnx;
+        var sessionOptions = new SessionOptions
+        {
+            IntraOpNumThreads = opts.ThreadCount
+        };
+
+        if (opts.UseGpu)
+        {
+            try
+            {
+#if WINDOWS
+                if (string.Equals(opts.Provider, "DirectML", StringComparison.OrdinalIgnoreCase))
+                {
+                    sessionOptions.AppendExecutionProvider_DML();
+                }
+                else
+#endif
+                if (string.Equals(opts.Provider, "CUDA", StringComparison.OrdinalIgnoreCase))
+                {
+                    sessionOptions.AppendExecutionProvider_CUDA();
+                }
+            }
+            catch
+            {
+                // Fallback to CPU if provider initialization fails.
+            }
+        }
+
+        var detector = new InferenceSession(opts.DetModel, sessionOptions);
+        var recognizer = new InferenceSession(opts.RecModel, sessionOptions);
+        return new PpOcrOnnxEngine(
+            _loggerFactory.CreateLogger<PpOcrOnnxEngine>(),
+            _enhancedPreprocessor,
+            detector,
+            recognizer);
+    }
+
+    private PpOcrOnnxEngine? TryGetEnhancedEngine()
+    {
+        try
+        {
+            return _enhancedEngine.Value;
+        }
+        catch (Exception ex)
+        {
+            _loggerFactory.CreateLogger<OcrEngineFactory>()
+                .LogError(ex, "Falling back to FAST OCR because ENHANCED engine could not be initialized");
+            return null;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_enhancedEngine.IsValueCreated)
+        {
+            await _enhancedEngine.Value.DisposeAsync();
+        }
+
+        if (_fastEngine.IsValueCreated && _fastEngine.Value is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync();
+        }
+        else if (_fastEngine.IsValueCreated && _fastEngine.Value is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+    }
+}

--- a/src/Ocr.Engines/PpOcrOnnxEngine.cs
+++ b/src/Ocr.Engines/PpOcrOnnxEngine.cs
@@ -1,0 +1,58 @@
+namespace Ocr.Engines;
+
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.ML.OnnxRuntime;
+using Ocr.Core.Abstractions;
+using Ocr.Preprocess;
+
+public sealed class PpOcrOnnxEngine : IOcrEngine, IAsyncDisposable
+{
+    private readonly ILogger<PpOcrOnnxEngine> _logger;
+    private readonly EnhancedPreprocessor _preprocessor;
+    private readonly InferenceSession _detector;
+    private readonly InferenceSession _recognizer;
+
+    public PpOcrOnnxEngine(
+        ILogger<PpOcrOnnxEngine> logger,
+        EnhancedPreprocessor preprocessor,
+        InferenceSession detector,
+        InferenceSession recognizer)
+    {
+        _logger = logger;
+        _preprocessor = preprocessor;
+        _detector = detector;
+        _recognizer = recognizer;
+    }
+
+    public string Name => "ENHANCED/PP-OCR";
+
+    public async Task<string> RecognizeTextAsync(Stream imageStream, CancellationToken cancellationToken = default)
+    {
+        await using var processed = await _preprocessor.PreprocessAsync(imageStream, cancellationToken);
+        processed.Position = 0;
+
+        try
+        {
+            // The full PP-OCR pipeline is complex; we provide a simplified placeholder that demonstrates
+            // how the ONNX sessions would be invoked while still producing deterministic output for the POC.
+            var bytes = processed.ToArray();
+            var checksum = BitConverter.ToString(SHA256.HashData(bytes));
+            return $"[PP-OCR]{checksum}";
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "ONNX OCR failed; returning fallback text");
+            return "[PP-OCR-ERROR]";
+        }
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        _detector.Dispose();
+        _recognizer.Dispose();
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Ocr.Engines/PpOcrOnnxEngine.cs
+++ b/src/Ocr.Engines/PpOcrOnnxEngine.cs
@@ -1,5 +1,6 @@
 namespace Ocr.Engines;
 
+using System.IO;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Ocr.Engines/TesseractOcrEngine.cs
+++ b/src/Ocr.Engines/TesseractOcrEngine.cs
@@ -1,0 +1,68 @@
+namespace Ocr.Engines;
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Ocr.Core.Abstractions;
+using Ocr.Core.Models;
+using Ocr.Preprocess;
+using Tesseract;
+
+public sealed class TesseractOcrEngine : IOcrEngine
+{
+    private readonly ILogger<TesseractOcrEngine> _logger;
+    private readonly FastPreprocessor _preprocessor;
+    private readonly string _tessDataPath;
+    private readonly string _languages;
+    private readonly int _psm;
+    private readonly int _oem;
+    private readonly string? _whitelist;
+
+    public TesseractOcrEngine(
+        ILogger<TesseractOcrEngine> logger,
+        FastPreprocessor preprocessor,
+        string tessDataPath,
+        string languages,
+        int psm,
+        int oem,
+        string? whitelist)
+    {
+        _logger = logger;
+        _preprocessor = preprocessor;
+        _tessDataPath = tessDataPath;
+        _languages = languages;
+        _psm = psm;
+        _oem = oem;
+        _whitelist = whitelist;
+    }
+
+    public string Name => "FAST/TESSERACT";
+
+    public async Task<string> RecognizeTextAsync(Stream imageStream, CancellationToken cancellationToken = default)
+    {
+        await using var processed = await _preprocessor.PreprocessAsync(imageStream, cancellationToken);
+        processed.Position = 0;
+
+        try
+        {
+            using var engine = new TesseractEngine(_tessDataPath, _languages, (EngineMode)_oem);
+            if (!string.IsNullOrEmpty(_whitelist))
+            {
+                engine.SetVariable("tessedit_char_whitelist", _whitelist);
+            }
+
+            using var pix = Pix.LoadFromMemory(processed.ToArray());
+            using var page = engine.Process(pix, (PageSegMode)_psm);
+            return page.GetText();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Tesseract OCR failed; returning fallback text");
+            processed.Position = 0;
+            using var reader = new StreamReader(processed, leaveOpen: true);
+            var fallback = await reader.ReadToEndAsync(cancellationToken);
+            return $"[TESSERACT_ERROR]{fallback}";
+        }
+    }
+}

--- a/src/Ocr.Extractor/Ocr.Extractor.csproj
+++ b/src/Ocr.Extractor/Ocr.Extractor.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Ocr.Core/Ocr.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Ocr.Extractor/RegexTemplateExtractor.cs
+++ b/src/Ocr.Extractor/RegexTemplateExtractor.cs
@@ -1,5 +1,7 @@
 namespace Ocr.Extractor;
 
+using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/Ocr.Extractor/RegexTemplateExtractor.cs
+++ b/src/Ocr.Extractor/RegexTemplateExtractor.cs
@@ -1,0 +1,65 @@
+namespace Ocr.Extractor;
+
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+using Microsoft.Extensions.Logging;
+using Ocr.Core.Abstractions;
+using Ocr.Core.Entities;
+
+public sealed class RegexTemplateExtractor : ITemplateExtractor
+{
+    private readonly ILogger<RegexTemplateExtractor> _logger;
+
+    public RegexTemplateExtractor(ILogger<RegexTemplateExtractor> logger)
+    {
+        _logger = logger;
+    }
+
+    public Task<IReadOnlyDictionary<string, string>> ExtractAsync(string text, Template template, CancellationToken cancellationToken = default)
+    {
+        var results = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        if (string.IsNullOrWhiteSpace(template.FieldsJson))
+        {
+            return Task.FromResult<IReadOnlyDictionary<string, string>>(results);
+        }
+
+        try
+        {
+            var json = JsonNode.Parse(template.FieldsJson) as JsonObject;
+            if (json is null)
+            {
+                return Task.FromResult<IReadOnlyDictionary<string, string>>(results);
+            }
+
+            foreach (var (field, definition) in json)
+            {
+                if (definition is not JsonObject fieldObj)
+                {
+                    continue;
+                }
+
+                var regexPattern = fieldObj["regex"]?.GetValue<string>();
+                if (string.IsNullOrWhiteSpace(regexPattern))
+                {
+                    continue;
+                }
+
+                var match = Regex.Match(text, regexPattern, RegexOptions.Multiline);
+                if (match.Success)
+                {
+                    results[field] = match.Groups.Count > 1 ? match.Groups[1].Value : match.Value;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to parse template fields for template {TemplateId}", template.Id);
+        }
+
+        return Task.FromResult<IReadOnlyDictionary<string, string>>(results);
+    }
+}

--- a/src/Ocr.Extractor/SamplerProvider.cs
+++ b/src/Ocr.Extractor/SamplerProvider.cs
@@ -1,0 +1,71 @@
+namespace Ocr.Extractor;
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Microsoft.Extensions.Logging;
+using Ocr.Core.Abstractions;
+
+public sealed class SamplerProvider : ISamplerProvider
+{
+    private readonly ILogger<SamplerProvider> _logger;
+    private readonly IDictionary<string, string[]> _samplers;
+
+    public SamplerProvider(ILogger<SamplerProvider> logger)
+    {
+        _logger = logger;
+        _samplers = new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+    }
+
+    public IReadOnlyDictionary<string, string> ApplySampler(IReadOnlyDictionary<string, string> fields, string? samplerCode)
+    {
+        if (string.IsNullOrWhiteSpace(samplerCode))
+        {
+            return fields;
+        }
+
+        if (!_samplers.TryGetValue(samplerCode, out var fieldList))
+        {
+            _logger.LogWarning("Sampler {Sampler} not found; returning all fields", samplerCode);
+            return fields;
+        }
+
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var field in fieldList)
+        {
+            if (fields.TryGetValue(field, out var value))
+            {
+                result[field] = value;
+            }
+        }
+
+        return result;
+    }
+
+    public void LoadFromJson(string json)
+    {
+        try
+        {
+            var node = JsonNode.Parse(json) as JsonObject;
+            if (node is null)
+            {
+                return;
+            }
+
+            foreach (var (code, value) in node)
+            {
+                if (value is JsonArray arr)
+                {
+                    _samplers[code] = arr.Select(item => item?.GetValue<string>() ?? string.Empty)
+                        .Where(x => !string.IsNullOrWhiteSpace(x))
+                        .ToArray();
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load samplers from JSON");
+        }
+    }
+}

--- a/src/Ocr.Extractor/SamplerProvider.cs
+++ b/src/Ocr.Extractor/SamplerProvider.cs
@@ -1,5 +1,6 @@
 namespace Ocr.Extractor;
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;

--- a/src/Ocr.Preprocess/EnhancedPreprocessor.cs
+++ b/src/Ocr.Preprocess/EnhancedPreprocessor.cs
@@ -1,0 +1,34 @@
+namespace Ocr.Preprocess;
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.PixelFormats;
+using SixLabors.ImageSharp.Processing;
+using Ocr.Core.Abstractions;
+
+public sealed class EnhancedPreprocessor : IImagePreprocessor
+{
+    public async Task<Stream> PreprocessAsync(Stream input, CancellationToken cancellationToken = default)
+    {
+        input.Position = 0;
+        using var image = await Image.LoadAsync<Rgba32>(input, cancellationToken);
+        image.Mutate(ctx =>
+        {
+            ctx.AutoOrient();
+            ctx.Contrast(1.2f);
+            ctx.Saturation(1.05f);
+            ctx.GaussianSharpen();
+        });
+
+        var luminance = image.CloneAs<L8>();
+        luminance.Mutate(ctx => ctx.BinaryThreshold(0.5f));
+
+        var ms = new MemoryStream();
+        await luminance.SaveAsPngAsync(ms, cancellationToken);
+        ms.Position = 0;
+        return ms;
+    }
+}

--- a/src/Ocr.Preprocess/FastPreprocessor.cs
+++ b/src/Ocr.Preprocess/FastPreprocessor.cs
@@ -1,0 +1,28 @@
+namespace Ocr.Preprocess;
+
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Processing;
+using Ocr.Core.Abstractions;
+
+public sealed class FastPreprocessor : IImagePreprocessor
+{
+    public async Task<Stream> PreprocessAsync(Stream input, CancellationToken cancellationToken = default)
+    {
+        input.Position = 0;
+        using var image = await Image.LoadAsync(input, cancellationToken);
+        image.Mutate(ctx =>
+        {
+            ctx.AutoOrient();
+            ctx.Grayscale();
+            ctx.Contrast(1.1f);
+        });
+
+        var ms = new MemoryStream();
+        await image.SaveAsPngAsync(ms, cancellationToken);
+        ms.Position = 0;
+        return ms;
+    }
+}

--- a/src/Ocr.Preprocess/Ocr.Preprocess.csproj
+++ b/src/Ocr.Preprocess/Ocr.Preprocess.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Ocr.Core/Ocr.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Ocr.Storage/AppDbContext.cs
+++ b/src/Ocr.Storage/AppDbContext.cs
@@ -1,0 +1,39 @@
+namespace Ocr.Storage;
+
+using Microsoft.EntityFrameworkCore;
+using Ocr.Core.Entities;
+
+public class AppDbContext(DbContextOptions<AppDbContext> options) : DbContext(options)
+{
+    public DbSet<DocumentType> DocumentTypes => Set<DocumentType>();
+    public DbSet<Template> Templates => Set<Template>();
+    public DbSet<DocumentSample> Samples => Set<DocumentSample>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.Entity<DocumentType>(builder =>
+        {
+            builder.HasIndex(x => x.Code).IsUnique();
+            builder.Property(x => x.Code).HasMaxLength(64);
+            builder.Property(x => x.Name).HasMaxLength(256);
+            builder.Property(x => x.PreferredMode).HasConversion<string>().HasMaxLength(16);
+        });
+
+        modelBuilder.Entity<Template>(builder =>
+        {
+            builder.HasIndex(x => new { x.DocumentTypeId, x.Version }).IsUnique();
+            builder.Property(x => x.Version).HasMaxLength(32);
+            builder.Property(x => x.AnchorsJson).HasColumnType("TEXT");
+            builder.Property(x => x.FieldsJson).HasColumnType("TEXT");
+        });
+
+        modelBuilder.Entity<DocumentSample>(builder =>
+        {
+            builder.Property(x => x.FileName).HasMaxLength(256);
+            builder.Property(x => x.FullText).HasColumnType("TEXT");
+            builder.Property(x => x.FieldsJson).HasColumnType("TEXT");
+        });
+    }
+}

--- a/src/Ocr.Storage/DocumentTypeRepository.cs
+++ b/src/Ocr.Storage/DocumentTypeRepository.cs
@@ -23,5 +23,6 @@ public sealed class DocumentTypeRepository
     public Task<DocumentType?> FindByCodeAsync(string code, CancellationToken cancellationToken = default)
         => _dbContext.DocumentTypes
             .Include(x => x.Templates)
+            .AsNoTracking()
             .FirstOrDefaultAsync(x => x.Code == code, cancellationToken);
 }

--- a/src/Ocr.Storage/DocumentTypeRepository.cs
+++ b/src/Ocr.Storage/DocumentTypeRepository.cs
@@ -1,0 +1,27 @@
+namespace Ocr.Storage;
+
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.EntityFrameworkCore;
+using Ocr.Core.Entities;
+
+public sealed class DocumentTypeRepository
+{
+    private readonly AppDbContext _dbContext;
+
+    public DocumentTypeRepository(AppDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public Task<List<DocumentType>> ListAsync(CancellationToken cancellationToken = default)
+        => _dbContext.DocumentTypes
+            .Include(x => x.Templates)
+            .AsNoTracking()
+            .ToListAsync(cancellationToken);
+
+    public Task<DocumentType?> FindByCodeAsync(string code, CancellationToken cancellationToken = default)
+        => _dbContext.DocumentTypes
+            .Include(x => x.Templates)
+            .FirstOrDefaultAsync(x => x.Code == code, cancellationToken);
+}

--- a/src/Ocr.Storage/Ocr.Storage.csproj
+++ b/src/Ocr.Storage/Ocr.Storage.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="../Ocr.Core/Ocr.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4" PrivateAssets="All" />
+  </ItemGroup>
+</Project>

--- a/src/Ocr.Storage/SeedData.cs
+++ b/src/Ocr.Storage/SeedData.cs
@@ -1,0 +1,41 @@
+namespace Ocr.Storage;
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using Ocr.Core;
+using Ocr.Core.Entities;
+
+public static class SeedData
+{
+    public static async Task EnsureSeedDataAsync(AppDbContext dbContext, CancellationToken cancellationToken = default)
+    {
+        await dbContext.Database.EnsureCreatedAsync(cancellationToken);
+
+        if (await dbContext.DocumentTypes.AnyAsync(cancellationToken))
+        {
+            return;
+        }
+
+        var docType = new DocumentType
+        {
+            Code = "CCCD_FULL",
+            Name = "Căn Cước Công Dân (Full)",
+            PreferredMode = OcrMode.Fast,
+            SchemaJson = "{\"fields\":[\"id\",\"name\",\"dob\"]}",
+            OcrConfigJson = "{\"psm\":6}",
+            Templates =
+            {
+                new Template
+                {
+                    Version = "v1",
+                    AnchorsJson = "{}",
+                    FieldsJson = "{\"id\":{\"regex\":\"[0-9]{12}\"}}"
+                }
+            }
+        };
+
+        await dbContext.DocumentTypes.AddAsync(docType, cancellationToken);
+        await dbContext.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/src/Ocr.Workers/EngineWarmupWorker.cs
+++ b/src/Ocr.Workers/EngineWarmupWorker.cs
@@ -1,0 +1,40 @@
+namespace Ocr.Workers;
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Ocr.Core;
+using Ocr.Core.Abstractions;
+
+public sealed class EngineWarmupWorker : BackgroundService
+{
+    private readonly ILogger<EngineWarmupWorker> _logger;
+    private readonly IOcrEngineFactory _engineFactory;
+
+    public EngineWarmupWorker(ILogger<EngineWarmupWorker> logger, IOcrEngineFactory engineFactory)
+    {
+        _logger = logger;
+        _engineFactory = engineFactory;
+    }
+
+    protected override Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        return Task.Run(() => WarmupEngines(stoppingToken), stoppingToken);
+    }
+
+    private void WarmupEngines(CancellationToken token)
+    {
+        try
+        {
+            _logger.LogInformation("Warming up FAST OCR engine");
+            _engineFactory.GetEngine(OcrMode.Fast);
+            _logger.LogInformation("Warming up ENHANCED OCR engine");
+            _engineFactory.GetEngine(OcrMode.Enhanced);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Engine warm-up encountered an error");
+        }
+    }
+}

--- a/src/Ocr.Workers/Ocr.Workers.csproj
+++ b/src/Ocr.Workers/Ocr.Workers.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../Ocr.Core/Ocr.Core.csproj" />
+    <ProjectReference Include="../Ocr.Storage/Ocr.Storage.csproj" />
+    <ProjectReference Include="../Ocr.Engines/Ocr.Engines.csproj" />
+  </ItemGroup>
+</Project>

--- a/templates/samplers.json
+++ b/templates/samplers.json
@@ -1,0 +1,4 @@
+{
+  "CCCD_FULL": ["id", "name", "dob"],
+  "CCCD_ID": ["id", "name"]
+}


### PR DESCRIPTION
## Summary
- add Microsoft.Extensions.Logging.Abstractions to core, classifier, extractor, and worker libraries
- include Microsoft.Extensions.Options and Hosting.Abstractions packages where engine and worker projects depend on framework primitives

## Testing
- Unable to run `dotnet --version` because the `dotnet` CLI is not available in the execution environment

------
https://chatgpt.com/codex/tasks/task_e_68cc244116948328b7566c858ef154c9