### PR TITLE
Update package references for .NET 9 compatibility

### DIFF
--- a/src/Ocr.Api/Ocr.Api.csproj
+++ b/src/Ocr.Api/Ocr.Api.csproj
@@ -9,7 +9,7 @@
     <ProjectReference Include="../Ocr.Workers/Ocr.Workers.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 </Project>

--- a/src/Ocr.Storage/Ocr.Storage.csproj
+++ b/src/Ocr.Storage/Ocr.Storage.csproj
@@ -3,8 +3,8 @@
     <ProjectReference Include="../Ocr.Core/Ocr.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9" PrivateAssets="All" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- align Microsoft.AspNetCore.OpenApi to the .NET 9 compatible release
- upgrade Entity Framework Core packages to the .NET 9 line to resolve package asset errors

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd2baf3b58832898acc843cf6fa877