### PR TITLE
Update package references for .NET 9 compatibility

### DIFF
--- a/src/Ocr.Api/Ocr.Api.csproj
+++ b/src/Ocr.Api/Ocr.Api.csproj
@@ -9,7 +9,7 @@
     <ProjectReference Include="../Ocr.Workers/Ocr.Workers.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.9" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 </Project>

--- a/src/Ocr.Classifier/Ocr.Classifier.csproj
+++ b/src/Ocr.Classifier/Ocr.Classifier.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
     <PackageReference Include="Microsoft.ML" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Ocr.Core/Ocr.Core.csproj" />

--- a/src/Ocr.Core/Ocr.Core.csproj
+++ b/src/Ocr.Core/Ocr.Core.csproj
@@ -1,2 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+  </ItemGroup>
 </Project>

--- a/src/Ocr.Engines/Ocr.Engines.csproj
+++ b/src/Ocr.Engines/Ocr.Engines.csproj
@@ -2,6 +2,8 @@
   <ItemGroup>
     <PackageReference Include="Tesseract" Version="5.0.0" />
     <PackageReference Include="Microsoft.ML.OnnxRuntime" Version="1.17.3" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="9.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="../Ocr.Core/Ocr.Core.csproj" />

--- a/src/Ocr.Extractor/Ocr.Extractor.csproj
+++ b/src/Ocr.Extractor/Ocr.Extractor.csproj
@@ -1,5 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="../Ocr.Core/Ocr.Core.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Ocr.Storage/Ocr.Storage.csproj
+++ b/src/Ocr.Storage/Ocr.Storage.csproj
@@ -3,8 +3,8 @@
     <ProjectReference Include="../Ocr.Core/Ocr.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.4" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.4" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.9" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Ocr.Workers/Ocr.Workers.csproj
+++ b/src/Ocr.Workers/Ocr.Workers.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="../Ocr.Core/Ocr.Core.csproj" />
     <ProjectReference Include="../Ocr.Storage/Ocr.Storage.csproj" />
     <ProjectReference Include="../Ocr.Engines/Ocr.Engines.csproj" />


### PR DESCRIPTION
## Summary
- align Microsoft.AspNetCore.OpenApi to the .NET 9 compatible release
- upgrade Entity Framework Core packages to the .NET 9 line to resolve package asset errors
- add Microsoft.Extensions logging, options, and hosting abstractions to class libraries so ILogger, options, and BackgroundService references compile

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68cd2baf3b58832898acc843cf6fa877