### PR TITLE
Use GetColumnOrNull for score column lookup

### DIFF
--- a/src/Ocr.Classifier/TextClassifier.cs
+++ b/src/Ocr.Classifier/TextClassifier.cs
@@ -70,18 +70,15 @@ public sealed class TextClassifier
                 }
             }
 
-            if (_predictionEngine.OutputSchema.TryGetColumnIndex(nameof(TextPrediction.Score), out var scoreColumnIndex))
+            var scoreColumn = _predictionEngine.OutputSchema.GetColumnOrNull(nameof(TextPrediction.Score));
+            if (scoreColumn is { } column && column.HasSlotNames())
             {
-                var scoreColumn = _predictionEngine.OutputSchema[scoreColumnIndex];
-                if (scoreColumn.HasSlotNames())
+                VBuffer<ReadOnlyMemory<char>> slotNames = default;
+                column.GetSlotNames(ref slotNames);
+                var names = slotNames.DenseValues().Select(memory => memory.ToString()).ToArray();
+                if (maxIndex < names.Length)
                 {
-                    VBuffer<ReadOnlyMemory<char>> slotNames = default;
-                    scoreColumn.GetSlotNames(ref slotNames);
-                    var names = slotNames.DenseValues().Select(memory => memory.ToString()).ToArray();
-                    if (maxIndex < names.Length)
-                    {
-                        return names[maxIndex];
-                    }
+                    return names[maxIndex];
                 }
             }
 


### PR DESCRIPTION
## Summary
- use the ML.NET 3.0.1 OutputSchema.GetColumnOrNull API when retrieving the score column in TextClassifier
- keep slot name lookup logic intact while handling the nullable column result

## Testing
- dotnet build ocr-suite.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ecb0523483288b3d0a68441b0045