### PR TITLE
Use GetColumnOrNull for score column lookup and fix OCR engine disposal

### DIFF
--- a/src/Ocr.Classifier/TextClassifier.cs
+++ b/src/Ocr.Classifier/TextClassifier.cs
@@ -70,18 +70,15 @@ public sealed class TextClassifier
                 }
             }
 
-            if (_predictionEngine.OutputSchema.TryGetColumnIndex(nameof(TextPrediction.Score), out var scoreColumnIndex))
+            var scoreColumn = _predictionEngine.OutputSchema.GetColumnOrNull(nameof(TextPrediction.Score));
+            if (scoreColumn is { } column && column.HasSlotNames())
             {
-                var scoreColumn = _predictionEngine.OutputSchema[scoreColumnIndex];
-                if (scoreColumn.HasSlotNames())
+                VBuffer<ReadOnlyMemory<char>> slotNames = default;
+                column.GetSlotNames(ref slotNames);
+                var names = slotNames.DenseValues().Select(memory => memory.ToString()).ToArray();
+                if (maxIndex < names.Length)
                 {
-                    VBuffer<ReadOnlyMemory<char>> slotNames = default;
-                    scoreColumn.GetSlotNames(ref slotNames);
-                    var names = slotNames.DenseValues().Select(memory => memory.ToString()).ToArray();
-                    if (maxIndex < names.Length)
-                    {
-                        return names[maxIndex];
-                    }
+                    return names[maxIndex];
                 }
             }
 

--- a/src/Ocr.Engines/OcrEngineFactory.cs
+++ b/src/Ocr.Engines/OcrEngineFactory.cs
@@ -46,7 +46,7 @@ public sealed class OcrEngineFactory : IOcrEngineFactory, IAsyncDisposable
 
         return effectiveMode switch
         {
-            OcrMode.Enhanced => TryGetEnhancedEngine() ?? _fastEngine.Value,
+            OcrMode.Enhanced => TryGetEnhancedEngine() ?? (IOcrEngine)_fastEngine.Value,
             OcrMode.Fast => _fastEngine.Value,
             _ => _fastEngine.Value
         };
@@ -104,7 +104,7 @@ public sealed class OcrEngineFactory : IOcrEngineFactory, IAsyncDisposable
             recognizer);
     }
 
-    private PpOcrOnnxEngine? TryGetEnhancedEngine()
+    private IOcrEngine? TryGetEnhancedEngine()
     {
         try
         {
@@ -124,13 +124,17 @@ public sealed class OcrEngineFactory : IOcrEngineFactory, IAsyncDisposable
             await _enhancedEngine.Value.DisposeAsync();
         }
 
-        if (_fastEngine.IsValueCreated && _fastEngine.Value is IAsyncDisposable asyncDisposable)
+        if (_fastEngine.IsValueCreated)
         {
-            await asyncDisposable.DisposeAsync();
-        }
-        else if (_fastEngine.IsValueCreated && _fastEngine.Value is IDisposable disposable)
-        {
-            disposable.Dispose();
+            object fastEngine = _fastEngine.Value;
+            if (fastEngine is IAsyncDisposable asyncDisposable)
+            {
+                await asyncDisposable.DisposeAsync();
+            }
+            else if (fastEngine is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
         }
     }
 }

--- a/src/Ocr.Engines/PpOcrOnnxEngine.cs
+++ b/src/Ocr.Engines/PpOcrOnnxEngine.cs
@@ -1,5 +1,7 @@
 namespace Ocr.Engines;
 
+using System;
+using System.IO;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
@@ -38,7 +40,7 @@ public sealed class PpOcrOnnxEngine : IOcrEngine, IAsyncDisposable
         {
             // The full PP-OCR pipeline is complex; we provide a simplified placeholder that demonstrates
             // how the ONNX sessions would be invoked while still producing deterministic output for the POC.
-            var bytes = processed.ToArray();
+            var bytes = ReadAllBytes(processed);
             var checksum = BitConverter.ToString(SHA256.HashData(bytes));
             return $"[PP-OCR]{checksum}";
         }
@@ -54,5 +56,18 @@ public sealed class PpOcrOnnxEngine : IOcrEngine, IAsyncDisposable
         _detector.Dispose();
         _recognizer.Dispose();
         return ValueTask.CompletedTask;
+    }
+
+    private static byte[] ReadAllBytes(Stream stream)
+    {
+        if (stream is MemoryStream memoryStream)
+        {
+            return memoryStream.ToArray();
+        }
+
+        stream.Position = 0;
+        using var copy = new MemoryStream();
+        stream.CopyTo(copy);
+        return copy.ToArray();
     }
 }

--- a/src/Ocr.Engines/TesseractOcrEngine.cs
+++ b/src/Ocr.Engines/TesseractOcrEngine.cs
@@ -52,7 +52,7 @@ public sealed class TesseractOcrEngine : IOcrEngine
                 engine.SetVariable("tessedit_char_whitelist", _whitelist);
             }
 
-            using var pix = Pix.LoadFromMemory(processed.ToArray());
+            using var pix = Pix.LoadFromMemory(ReadAllBytes(processed));
             using var page = engine.Process(pix, (PageSegMode)_psm);
             return page.GetText();
         }
@@ -64,5 +64,18 @@ public sealed class TesseractOcrEngine : IOcrEngine
             var fallback = await reader.ReadToEndAsync(cancellationToken);
             return $"[TESSERACT_ERROR]{fallback}";
         }
+    }
+
+    private static byte[] ReadAllBytes(Stream stream)
+    {
+        if (stream is MemoryStream memoryStream)
+        {
+            return memoryStream.ToArray();
+        }
+
+        stream.Position = 0;
+        using var copy = new MemoryStream();
+        stream.CopyTo(copy);
+        return copy.ToArray();
     }
 }


### PR DESCRIPTION
## Summary
- use the ML.NET 3.0.1 OutputSchema.GetColumnOrNull API when retrieving the score column in TextClassifier
- keep slot name lookup logic intact while handling the nullable column result
- adjust OcrEngineFactory to return IOcrEngine when enhanced creation fails and dispose lazily-created engines safely
- replace Stream.ToArray usages in OCR engines with a compatibility helper that works with non-MemoryStream implementations

## Testing
- dotnet build ocr-suite.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ecb0523483288b3d0a68441b0045