### PR TITLE
Serve test UI from static files

### DIFF
--- a/src/Ocr.Api/wwwroot/test/index.html
+++ b/src/Ocr.Api/wwwroot/test/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>OCR Suite Test</title>
+  <link rel="stylesheet" href="test.css" />
+</head>
+<body>
+  <h1>OCR Suite – Test UI</h1>
+  <form id="ocr-form" enctype="multipart/form-data">
+    <label>Chọn ảnh/PDF: <input type="file" name="file" required /></label>
+    <label>Mã loại tài liệu (tùy chọn): <input name="docType" placeholder="VD: CCCD_FULL" /></label>
+    <label>Sampler (tùy chọn): <input name="sampler" placeholder="VD: CCCD_ID" /></label>
+    <label>Chế độ OCR:
+      <select name="mode">
+        <option value="AUTO">Auto</option>
+        <option value="FAST">Fast (Tesseract)</option>
+        <option value="ENHANCED">Enhanced (ONNX)</option>
+      </select>
+    </label>
+    <button type="submit">Nhận dạng</button>
+  </form>
+  <h2>Kết quả</h2>
+  <pre id="result"></pre>
+  <script src="test.js"></script>
+</body>
+</html>

--- a/src/Ocr.Api/wwwroot/test/test.css
+++ b/src/Ocr.Api/wwwroot/test/test.css
@@ -1,0 +1,26 @@
+body {
+  font-family: sans-serif;
+  margin: 40px;
+}
+
+label {
+  display: block;
+  margin-top: 12px;
+}
+
+textarea,
+pre {
+  width: 100%;
+  min-height: 160px;
+  background: #f5f5f5;
+  padding: 12px;
+  border-radius: 4px;
+  border: 1px solid #ddd;
+  box-sizing: border-box;
+  white-space: pre-wrap;
+}
+
+button {
+  margin-top: 16px;
+  padding: 10px 16px;
+}

--- a/src/Ocr.Api/wwwroot/test/test.js
+++ b/src/Ocr.Api/wwwroot/test/test.js
@@ -1,0 +1,32 @@
+(() => {
+  const form = document.getElementById('ocr-form');
+  const resultEl = document.getElementById('result');
+
+  if (!form || !resultEl) {
+    return;
+  }
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const data = new FormData(form);
+    resultEl.textContent = 'Đang xử lý...';
+
+    try {
+      const response = await fetch('/api/ocr', {
+        method: 'POST',
+        body: data
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        resultEl.textContent = `Lỗi: ${errorText}`;
+        return;
+      }
+
+      const json = await response.json();
+      resultEl.textContent = JSON.stringify(json, null, 2);
+    } catch (error) {
+      resultEl.textContent = `Lỗi: ${error instanceof Error ? error.message : String(error)}`;
+    }
+  });
+})();

--- a/src/Ocr.Classifier/TextClassifier.cs
+++ b/src/Ocr.Classifier/TextClassifier.cs
@@ -70,18 +70,15 @@ public sealed class TextClassifier
                 }
             }
 
-            if (_predictionEngine.OutputSchema.TryGetColumnIndex(nameof(TextPrediction.Score), out var scoreColumnIndex))
+            var scoreColumn = _predictionEngine.OutputSchema.GetColumnOrNull(nameof(TextPrediction.Score));
+            if (scoreColumn is { } column && column.HasSlotNames())
             {
-                var scoreColumn = _predictionEngine.OutputSchema[scoreColumnIndex];
-                if (scoreColumn.HasSlotNames())
+                VBuffer<ReadOnlyMemory<char>> slotNames = default;
+                column.GetSlotNames(ref slotNames);
+                var names = slotNames.DenseValues().Select(memory => memory.ToString()).ToArray();
+                if (maxIndex < names.Length)
                 {
-                    VBuffer<ReadOnlyMemory<char>> slotNames = default;
-                    scoreColumn.GetSlotNames(ref slotNames);
-                    var names = slotNames.DenseValues().Select(memory => memory.ToString()).ToArray();
-                    if (maxIndex < names.Length)
-                    {
-                        return names[maxIndex];
-                    }
+                    return names[maxIndex];
                 }
             }
 

--- a/src/Ocr.Engines/OcrEngineFactory.cs
+++ b/src/Ocr.Engines/OcrEngineFactory.cs
@@ -46,7 +46,7 @@ public sealed class OcrEngineFactory : IOcrEngineFactory, IAsyncDisposable
 
         return effectiveMode switch
         {
-            OcrMode.Enhanced => TryGetEnhancedEngine() ?? _fastEngine.Value,
+            OcrMode.Enhanced => TryGetEnhancedEngine() ?? (IOcrEngine)_fastEngine.Value,
             OcrMode.Fast => _fastEngine.Value,
             _ => _fastEngine.Value
         };
@@ -104,7 +104,7 @@ public sealed class OcrEngineFactory : IOcrEngineFactory, IAsyncDisposable
             recognizer);
     }
 
-    private PpOcrOnnxEngine? TryGetEnhancedEngine()
+    private IOcrEngine? TryGetEnhancedEngine()
     {
         try
         {
@@ -124,13 +124,17 @@ public sealed class OcrEngineFactory : IOcrEngineFactory, IAsyncDisposable
             await _enhancedEngine.Value.DisposeAsync();
         }
 
-        if (_fastEngine.IsValueCreated && _fastEngine.Value is IAsyncDisposable asyncDisposable)
+        if (_fastEngine.IsValueCreated)
         {
-            await asyncDisposable.DisposeAsync();
-        }
-        else if (_fastEngine.IsValueCreated && _fastEngine.Value is IDisposable disposable)
-        {
-            disposable.Dispose();
+            object fastEngine = _fastEngine.Value;
+            if (fastEngine is IAsyncDisposable asyncDisposable)
+            {
+                await asyncDisposable.DisposeAsync();
+            }
+            else if (fastEngine is IDisposable disposable)
+            {
+                disposable.Dispose();
+            }
         }
     }
 }

--- a/src/Ocr.Engines/PpOcrOnnxEngine.cs
+++ b/src/Ocr.Engines/PpOcrOnnxEngine.cs
@@ -1,5 +1,7 @@
 namespace Ocr.Engines;
 
+using System;
+using System.IO;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
@@ -38,7 +40,7 @@ public sealed class PpOcrOnnxEngine : IOcrEngine, IAsyncDisposable
         {
             // The full PP-OCR pipeline is complex; we provide a simplified placeholder that demonstrates
             // how the ONNX sessions would be invoked while still producing deterministic output for the POC.
-            var bytes = processed.ToArray();
+            var bytes = ReadAllBytes(processed);
             var checksum = BitConverter.ToString(SHA256.HashData(bytes));
             return $"[PP-OCR]{checksum}";
         }
@@ -54,5 +56,18 @@ public sealed class PpOcrOnnxEngine : IOcrEngine, IAsyncDisposable
         _detector.Dispose();
         _recognizer.Dispose();
         return ValueTask.CompletedTask;
+    }
+
+    private static byte[] ReadAllBytes(Stream stream)
+    {
+        if (stream is MemoryStream memoryStream)
+        {
+            return memoryStream.ToArray();
+        }
+
+        stream.Position = 0;
+        using var copy = new MemoryStream();
+        stream.CopyTo(copy);
+        return copy.ToArray();
     }
 }

--- a/src/Ocr.Engines/TesseractOcrEngine.cs
+++ b/src/Ocr.Engines/TesseractOcrEngine.cs
@@ -52,7 +52,7 @@ public sealed class TesseractOcrEngine : IOcrEngine
                 engine.SetVariable("tessedit_char_whitelist", _whitelist);
             }
 
-            using var pix = Pix.LoadFromMemory(processed.ToArray());
+            using var pix = Pix.LoadFromMemory(ReadAllBytes(processed));
             using var page = engine.Process(pix, (PageSegMode)_psm);
             return page.GetText();
         }
@@ -64,5 +64,18 @@ public sealed class TesseractOcrEngine : IOcrEngine
             var fallback = await reader.ReadToEndAsync(cancellationToken);
             return $"[TESSERACT_ERROR]{fallback}";
         }
+    }
+
+    private static byte[] ReadAllBytes(Stream stream)
+    {
+        if (stream is MemoryStream memoryStream)
+        {
+            return memoryStream.ToArray();
+        }
+
+        stream.Position = 0;
+        using var copy = new MemoryStream();
+        stream.CopyTo(copy);
+        return copy.ToArray();
     }
 }


### PR DESCRIPTION
## Summary
- serve the `/test` endpoint from a static HTML file and load supporting CSS and JavaScript assets
- enable static file middleware so the test UI resources are accessible alongside the API surface

## Testing
- dotnet build ocr-suite.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ecb0523483288b3d0a68441b0045