### PR TITLE
Resolve logging ambiguities and fix stream result

### DIFF
--- a/src/Ocr.Api/Program.cs
+++ b/src/Ocr.Api/Program.cs
@@ -1,6 +1,8 @@
 using System.Linq;
 using System.IO;
+using System.Net.Mime;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.Extensions.Hosting;
 using Microsoft.EntityFrameworkCore;
@@ -27,7 +29,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Host.UseSerilog(Log.Logger, dispose: true);
 
-builder.Services.AddSingleton<ILogger>(Log.Logger);
+builder.Services.AddSingleton<Serilog.ILogger>(Log.Logger);
 
 builder.Services.AddOptions();
 builder.Services.Configure<OcrOptions>(builder.Configuration.GetSection("Ocr"));
@@ -43,7 +45,7 @@ builder.Services.AddSingleton<EnhancedPreprocessor>();
 builder.Services.AddSingleton<RegexTemplateExtractor>();
 builder.Services.AddSingleton<SamplerProvider>(sp =>
 {
-    var provider = new SamplerProvider(sp.GetRequiredService<ILogger>());
+    var provider = new SamplerProvider(sp.GetRequiredService<Serilog.ILogger>());
     var env = sp.GetRequiredService<IHostEnvironment>();
     var path = Path.Combine(env.ContentRootPath, "templates", "samplers.json");
     if (File.Exists(path))
@@ -62,7 +64,7 @@ builder.Services.AddScoped<OcrCoordinator>(sp =>
 {
     var repository = sp.GetRequiredService<DocumentTypeRepository>();
     return new OcrCoordinator(
-        sp.GetRequiredService<ILogger>(),
+        sp.GetRequiredService<Serilog.ILogger>(),
         sp.GetRequiredService<IOcrEngineFactory>(),
         sp.GetRequiredService<ITemplateExtractor>(),
         sp.GetRequiredService<ISamplerProvider>(),
@@ -85,6 +87,8 @@ var app = builder.Build();
 
 app.UseSwagger();
 app.UseSwaggerUI();
+
+app.UseStaticFiles();
 
 using (var scope = app.Services.CreateScope())
 {
@@ -133,52 +137,16 @@ app.MapPost("/api/ocr", async Task<Results<Ok<OcrResult>, BadRequest<string>>> (
     return TypedResults.Ok(result);
 });
 
-app.MapGet("/test", () => Results.Content(@"<!DOCTYPE html>
-<html lang=\"en\">
-<head>
-  <meta charset=\"utf-8\" />
-  <title>OCR Suite Test</title>
-  <style>
-    body { font-family: sans-serif; margin: 40px; }
-    label { display: block; margin-top: 12px; }
-    textarea { width: 100%; min-height: 160px; }
-  </style>
-</head>
-<body>
-  <h1>OCR Suite – Test UI</h1>
-  <form id=\"ocr-form\" enctype=\"multipart/form-data\">
-    <label>Chọn ảnh/PDF: <input type=\"file\" name=\"file\" required /></label>
-    <label>Mã loại tài liệu (tùy chọn): <input name=\"docType\" placeholder=\"VD: CCCD_FULL\" /></label>
-    <label>Sampler (tùy chọn): <input name=\"sampler\" placeholder=\"VD: CCCD_ID\" /></label>
-    <label>Chế độ OCR:
-      <select name=\"mode\">
-        <option value=\"AUTO\">Auto</option>
-        <option value=\"FAST\">Fast (Tesseract)</option>
-        <option value=\"ENHANCED\">Enhanced (ONNX)</option>
-      </select>
-    </label>
-    <button type=\"submit\">Nhận dạng</button>
-  </form>
-  <h2>Kết quả</h2>
-  <pre id=\"result\"></pre>
-  <script>
-    const form = document.getElementById('ocr-form');
-    const resultEl = document.getElementById('result');
-    form.addEventListener('submit', async (event) => {
-      event.preventDefault();
-      const data = new FormData(form);
-      resultEl.textContent = 'Đang xử lý...';
-      const response = await fetch('/api/ocr', { method: 'POST', body: data });
-      if (!response.ok) {
-        resultEl.textContent = 'Lỗi: ' + await response.text();
-        return;
-      }
-      const json = await response.json();
-      resultEl.textContent = JSON.stringify(json, null, 2);
-    });
-  </script>
-</body>
-</html>", "text/html"));
+app.MapGet("/test", (IWebHostEnvironment env) =>
+{
+    var file = env.WebRootFileProvider.GetFileInfo("test/index.html");
+    if (!file.Exists)
+    {
+        return Results.Problem("Test view not found", statusCode: StatusCodes.Status500InternalServerError);
+    }
+
+    return Results.Stream(() => file.CreateReadStream(), MediaTypeNames.Text.Html);
+});
 
 app.Run();
 

--- a/src/Ocr.Api/wwwroot/test/index.html
+++ b/src/Ocr.Api/wwwroot/test/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>OCR Suite Test</title>
+  <link rel="stylesheet" href="test.css" />
+</head>
+<body>
+  <h1>OCR Suite – Test UI</h1>
+  <form id="ocr-form" enctype="multipart/form-data">
+    <label>Chọn ảnh/PDF: <input type="file" name="file" required /></label>
+    <label>Mã loại tài liệu (tùy chọn): <input name="docType" placeholder="VD: CCCD_FULL" /></label>
+    <label>Sampler (tùy chọn): <input name="sampler" placeholder="VD: CCCD_ID" /></label>
+    <label>Chế độ OCR:
+      <select name="mode">
+        <option value="AUTO">Auto</option>
+        <option value="FAST">Fast (Tesseract)</option>
+        <option value="ENHANCED">Enhanced (ONNX)</option>
+      </select>
+    </label>
+    <button type="submit">Nhận dạng</button>
+  </form>
+  <h2>Kết quả</h2>
+  <pre id="result"></pre>
+  <script src="test.js"></script>
+</body>
+</html>

--- a/src/Ocr.Api/wwwroot/test/test.css
+++ b/src/Ocr.Api/wwwroot/test/test.css
@@ -1,0 +1,26 @@
+body {
+  font-family: sans-serif;
+  margin: 40px;
+}
+
+label {
+  display: block;
+  margin-top: 12px;
+}
+
+textarea,
+pre {
+  width: 100%;
+  min-height: 160px;
+  background: #f5f5f5;
+  padding: 12px;
+  border-radius: 4px;
+  border: 1px solid #ddd;
+  box-sizing: border-box;
+  white-space: pre-wrap;
+}
+
+button {
+  margin-top: 16px;
+  padding: 10px 16px;
+}

--- a/src/Ocr.Api/wwwroot/test/test.js
+++ b/src/Ocr.Api/wwwroot/test/test.js
@@ -1,0 +1,32 @@
+(() => {
+  const form = document.getElementById('ocr-form');
+  const resultEl = document.getElementById('result');
+
+  if (!form || !resultEl) {
+    return;
+  }
+
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const data = new FormData(form);
+    resultEl.textContent = 'Đang xử lý...';
+
+    try {
+      const response = await fetch('/api/ocr', {
+        method: 'POST',
+        body: data
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        resultEl.textContent = `Lỗi: ${errorText}`;
+        return;
+      }
+
+      const json = await response.json();
+      resultEl.textContent = JSON.stringify(json, null, 2);
+    } catch (error) {
+      resultEl.textContent = `Lỗi: ${error instanceof Error ? error.message : String(error)}`;
+    }
+  });
+})();

--- a/src/Ocr.Classifier/TextClassifier.cs
+++ b/src/Ocr.Classifier/TextClassifier.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Microsoft.ML;
 using Microsoft.ML.Data;
 using Serilog;
+using ILogger = Serilog.ILogger;
 
 public sealed class TextClassifier
 {
@@ -70,18 +71,15 @@ public sealed class TextClassifier
                 }
             }
 
-            if (_predictionEngine.OutputSchema.TryGetColumnIndex(nameof(TextPrediction.Score), out var scoreColumnIndex))
+            var scoreColumn = _predictionEngine.OutputSchema.GetColumnOrNull(nameof(TextPrediction.Score));
+            if (scoreColumn is { } column && column.HasSlotNames())
             {
-                var scoreColumn = _predictionEngine.OutputSchema[scoreColumnIndex];
-                if (scoreColumn.HasSlotNames())
+                VBuffer<ReadOnlyMemory<char>> slotNames = default;
+                column.GetSlotNames(ref slotNames);
+                var names = slotNames.DenseValues().Select(memory => memory.ToString()).ToArray();
+                if (maxIndex < names.Length)
                 {
-                    VBuffer<ReadOnlyMemory<char>> slotNames = default;
-                    scoreColumn.GetSlotNames(ref slotNames);
-                    var names = slotNames.DenseValues().Select(memory => memory.ToString()).ToArray();
-                    if (maxIndex < names.Length)
-                    {
-                        return names[maxIndex];
-                    }
+                    return names[maxIndex];
                 }
             }
 

--- a/src/Ocr.Core/Services/OcrCoordinator.cs
+++ b/src/Ocr.Core/Services/OcrCoordinator.cs
@@ -3,10 +3,11 @@ namespace Ocr.Core.Services;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Serilog;
 using Ocr.Core.Abstractions;
 using Ocr.Core.Entities;
 using Ocr.Core.Models;
+using Serilog;
+using ILogger = Serilog.ILogger;
 
 public sealed class OcrCoordinator
 {

--- a/src/Ocr.Extractor/RegexTemplateExtractor.cs
+++ b/src/Ocr.Extractor/RegexTemplateExtractor.cs
@@ -5,9 +5,10 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Text.Json.Nodes;
 using System.Text.RegularExpressions;
-using Serilog;
 using Ocr.Core.Abstractions;
 using Ocr.Core.Entities;
+using Serilog;
+using ILogger = Serilog.ILogger;
 
 public sealed class RegexTemplateExtractor : ITemplateExtractor
 {

--- a/src/Ocr.Extractor/SamplerProvider.cs
+++ b/src/Ocr.Extractor/SamplerProvider.cs
@@ -4,8 +4,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using Serilog;
 using Ocr.Core.Abstractions;
+using Serilog;
+using ILogger = Serilog.ILogger;
 
 public sealed class SamplerProvider : ISamplerProvider
 {

--- a/src/Ocr.Workers/EngineWarmupWorker.cs
+++ b/src/Ocr.Workers/EngineWarmupWorker.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Hosting;
 using Ocr.Core;
 using Ocr.Core.Abstractions;
 using Serilog;
+using ILogger = Serilog.ILogger;
 
 public sealed class EngineWarmupWorker : BackgroundService
 {


### PR DESCRIPTION
## Summary
- register and request the Serilog logger explicitly in the API startup to avoid ambiguity with Microsoft.Extensions logging abstractions
- add Serilog logger aliases across OCR components that rely on ForContext to ensure they bind to the intended logger implementation
- wrap the test view stream response in a lambda so it matches the Results.Stream signature on .NET 9

## Testing
- dotnet build ocr-suite.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d0ecb0523483288b3d0a68441b0045