### PR TITLE
feat: add admin mock ui and enhanced test client

### DIFF
--- a/docs/business-requirements.md
+++ b/docs/business-requirements.md
@@ -1,0 +1,65 @@
+# Phân tích yêu cầu nghiệp vụ UI OCR Suite
+
+Tài liệu này tổng hợp lại các yêu cầu nghiệp vụ chính cho khối giao diện quản trị và màn hình kiểm thử end-user của hệ thống OCR Suite. Phần này được dùng làm nguồn tham chiếu khi xây dựng mock UI và API phục vụ việc demo luồng nghiệp vụ.
+
+## 1. Bối cảnh hệ thống
+
+Hệ thống OCR Suite hoạt động on-premise với hai chế độ nhận dạng:
+
+- **FAST (Tesseract)**: tốc độ cao, dành cho tài liệu chất lượng tốt.
+- **ENHANCED (PP-OCR ONNX)**: tăng độ chính xác cho tài liệu khó.
+
+Kho dữ liệu quản lý các loại tài liệu (`DocumentType`), mẫu trích xuất (`Template`), mẫu sampler (`Sampler`) và bộ mẫu cần gán nhãn (`DocumentSample`).
+
+## 2. Mục tiêu giao diện quản trị
+
+Giao diện quản trị phục vụ đội vận hành/labeling với các chức năng chính:
+
+1. **Quản lý loại tài liệu (Document Type)**
+   - Xem danh sách với các chỉ số: số mẫu, số mẫu đã gán nhãn, template đang hoạt động, lần huấn luyện gần nhất.
+   - Tạo, cập nhật thông tin: mã, tên, mô tả, chế độ OCR ưa thích, schema trường dữ liệu, cấu hình OCR.
+
+2. **Quản lý mẫu tài liệu (Samples)**
+   - Tải lên và theo dõi trạng thái từng mẫu.
+   - Mở màn hình gán nhãn: xem ảnh, xem kết quả OCR thô, nhập fulltext chuẩn, nhập giá trị theo trường, lưu nhãn.
+   - Cho phép sử dụng gợi ý OCR và ghi chú nội bộ.
+
+3. **Quản lý template trích xuất**
+   - Chỉnh sửa JSON anchors/regex và cấu hình trường.
+   - Kiểm thử template trên mẫu có sẵn để xem kết quả khớp trường.
+   - Quản lý trạng thái kích hoạt và phiên bản template.
+
+4. **Quản lý sampler**
+   - Khai báo sampler theo bộ trường con phục vụ API end-user.
+   - Bật/tắt sampler, cập nhật mô tả.
+
+5. **Huấn luyện nhanh (FAST tuning)**
+   - Kích hoạt grid-search cho tham số FAST (psm, preprocess, whitelist).
+   - Theo dõi lịch sử lần chạy gần nhất và ghi chú kết quả.
+
+## 3. Mục tiêu giao diện kiểm thử end-user (`/test`)
+
+Giao diện kiểm thử dành cho người dùng nghiệp vụ test nhanh pipeline:
+
+- Upload tệp ảnh/PDF, chọn mode OCR (AUTO/FAST/ENHANCED), docType, sampler.
+- Nhận kết quả gồm: docType phân loại, chế độ đã dùng, danh sách trường trích xuất, metadata.
+- Có nút xem fulltext, tải JSON kết quả.
+- Đề xuất chuyển sang ENHANCED nếu chạy FAST nhưng kết quả nghi ngờ (fulltext ngắn, thiếu trường).
+
+## 4. Luồng nghiệp vụ trọng tâm
+
+1. **Tạo loại tài liệu mới** → cấu hình schema/template cơ bản → upload mẫu thử → gán nhãn → test template → huấn luyện FAST.
+2. **Gán nhãn mẫu** → lưu fulltext, giá trị trường → đánh dấu hoàn tất → dữ liệu dùng cho huấn luyện/tối ưu.
+3. **Tối ưu template** → chỉnh sửa anchors/regex → test với mẫu → ghi lại kết quả test.
+4. **Phát hành sampler** → định nghĩa bộ trường con → bật sampler phục vụ API.
+5. **Test end-user** → upload tài liệu thực tế → kiểm tra kết quả → tải JSON cho tích hợp.
+
+## 5. Phạm vi mock/demo
+
+Trong phạm vi mock UI/API:
+
+- Dữ liệu được lưu ở bộ nhớ tạm với vài docType mẫu (CCCD_FULL, CCCD_ID, HO_KHAU).
+- Cho phép thực hiện đầy đủ thao tác CRUD cần thiết để mô phỏng luồng nghiệp vụ.
+- Các API `/api/mock/**` chỉ phục vụ demo UI, không ghi xuống cơ sở dữ liệu thật.
+- Các thao tác nặng (huấn luyện, test template) trả về kết quả tức thời với dữ liệu giả lập để hỗ trợ verify giao diện.
+

--- a/src/Ocr.Api/Mock/AdminMockEndpointExtensions.cs
+++ b/src/Ocr.Api/Mock/AdminMockEndpointExtensions.cs
@@ -1,0 +1,307 @@
+namespace Ocr.Api.Mock;
+
+using System;
+using System.Linq;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+public static class AdminMockEndpointExtensions
+{
+    public static void MapAdminMockEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/api/mock");
+
+        group.MapGet("/doc-types", (AdminMockStore store) =>
+        {
+            var docTypes = store.GetDocTypes().Select(MapDocTypeSummary);
+            return Results.Ok(docTypes);
+        });
+
+        group.MapPost("/doc-types", (AdminMockStore store, DocTypeUpsertRequest request) =>
+        {
+            if (string.IsNullOrWhiteSpace(request.Code) || string.IsNullOrWhiteSpace(request.Name))
+            {
+                return Results.BadRequest("Code và Name không được để trống");
+            }
+
+            if (store.GetDocTypes().Any(dt => string.Equals(dt.Code, request.Code, StringComparison.OrdinalIgnoreCase)))
+            {
+                return Results.BadRequest("Mã loại tài liệu đã tồn tại");
+            }
+
+            var created = store.CreateDocType(request);
+            return Results.Ok(MapDocTypeDetail(created));
+        });
+
+        group.MapGet("/doc-types/{id:int}", (int id, AdminMockStore store) =>
+        {
+            var docType = store.FindDocType(id);
+            return docType is null ? Results.NotFound() : Results.Ok(MapDocTypeDetail(docType));
+        });
+
+        group.MapPut("/doc-types/{id:int}", (int id, AdminMockStore store, DocTypeUpsertRequest request) =>
+        {
+            if (string.IsNullOrWhiteSpace(request.Name))
+            {
+                return Results.BadRequest("Tên loại tài liệu không được để trống");
+            }
+
+            try
+            {
+                var updated = store.UpdateDocType(id, request);
+                return Results.Ok(MapDocTypeDetail(updated));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.NotFound(ex.Message);
+            }
+        });
+
+        group.MapGet("/doc-types/{id:int}/samples", (int id, AdminMockStore store) =>
+        {
+            var docType = store.FindDocType(id);
+            return docType is null
+                ? Results.NotFound()
+                : Results.Ok(docType.Samples.Select(MapSample));
+        });
+
+        group.MapPost("/doc-types/{id:int}/samples", (int id, AdminMockStore store, SampleCreateRequest request) =>
+        {
+            try
+            {
+                var sample = store.CreateSample(id, request);
+                return Results.Ok(MapSample(sample));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+        });
+
+        group.MapGet("/samples/{sampleId:int}", (int sampleId, AdminMockStore store) =>
+        {
+            var sample = store.FindSample(sampleId);
+            return sample is null ? Results.NotFound() : Results.Ok(MapSample(sample));
+        });
+
+        group.MapPut("/samples/{sampleId:int}/label", (int sampleId, AdminMockStore store, SampleLabelRequest request) =>
+        {
+            try
+            {
+                var updated = store.UpdateSampleLabel(sampleId, request);
+                return Results.Ok(MapSample(updated));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+        });
+
+        group.MapGet("/doc-types/{id:int}/templates", (int id, AdminMockStore store) =>
+        {
+            var docType = store.FindDocType(id);
+            return docType is null
+                ? Results.NotFound()
+                : Results.Ok(docType.Templates.Select(MapTemplate));
+        });
+
+        group.MapPost("/doc-types/{id:int}/templates", (int id, AdminMockStore store, TemplateUpsertRequest request) =>
+        {
+            try
+            {
+                var created = store.CreateTemplate(id, request);
+                return Results.Ok(MapTemplate(created));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+        });
+
+        group.MapPut("/templates/{templateId:int}", (int templateId, AdminMockStore store, TemplateUpsertRequest request) =>
+        {
+            try
+            {
+                var updated = store.UpdateTemplate(templateId, request);
+                return Results.Ok(MapTemplate(updated));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+        });
+
+        group.MapPost("/doc-types/{docTypeId:int}/templates/{templateId:int}/test", (int docTypeId, int templateId, AdminMockStore store, TemplateTestRequest request) =>
+        {
+            try
+            {
+                var result = store.TestTemplate(docTypeId, templateId, request);
+                return Results.Ok(MapTemplateTest(result));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+        });
+
+        group.MapGet("/doc-types/{id:int}/samplers", (int id, AdminMockStore store) =>
+        {
+            var docType = store.FindDocType(id);
+            return docType is null
+                ? Results.NotFound()
+                : Results.Ok(docType.Samplers.Select(MapSampler));
+        });
+
+        group.MapPost("/doc-types/{id:int}/samplers", (int id, AdminMockStore store, SamplerUpsertRequest request) =>
+        {
+            try
+            {
+                var created = store.CreateSampler(id, request);
+                return Results.Ok(MapSampler(created));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+        });
+
+        group.MapPut("/samplers/{samplerId:int}", (int samplerId, AdminMockStore store, SamplerUpsertRequest request) =>
+        {
+            try
+            {
+                var updated = store.UpdateSampler(samplerId, request);
+                return Results.Ok(MapSampler(updated));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+        });
+
+        group.MapPost("/doc-types/{docTypeId:int}/train", (int docTypeId, AdminMockStore store, TrainingRequest request) =>
+        {
+            try
+            {
+                var job = store.TriggerTraining(docTypeId, request);
+                return Results.Ok(MapTraining(job));
+            }
+            catch (InvalidOperationException ex)
+            {
+                return Results.BadRequest(ex.Message);
+            }
+        });
+    }
+
+    private static object MapDocTypeSummary(MockDocumentType docType)
+        => new
+        {
+            docType.Id,
+            docType.Code,
+            docType.Name,
+            docType.Description,
+            PreferredMode = docType.PreferredMode.ToString().ToUpperInvariant(),
+            docType.SchemaJson,
+            docType.OcrConfigJson,
+            docType.OnnxConfigJson,
+            docType.CreatedAt,
+            docType.UpdatedAt,
+            Stats = new
+            {
+                Samples = docType.Samples.Count,
+                Labeled = docType.Samples.Count(s => s.IsLabeled),
+                Templates = docType.Templates.Count,
+                Samplers = docType.Samplers.Count
+            },
+            ActiveTemplate = docType.Templates.FirstOrDefault(t => t.IsActive)?.Version,
+            LastTraining = docType.TrainingJobs.OrderByDescending(t => t.CompletedAt ?? t.CreatedAt).Select(MapTraining).FirstOrDefault()
+        };
+
+    private static object MapDocTypeDetail(MockDocumentType docType)
+        => new
+        {
+            docType.Id,
+            docType.Code,
+            docType.Name,
+            docType.Description,
+            PreferredMode = docType.PreferredMode.ToString().ToUpperInvariant(),
+            docType.SchemaJson,
+            docType.OcrConfigJson,
+            docType.OnnxConfigJson,
+            docType.CreatedAt,
+            docType.UpdatedAt,
+            Templates = docType.Templates.Select(MapTemplate).ToList(),
+            Samplers = docType.Samplers.Select(MapSampler).ToList(),
+            Samples = docType.Samples.Select(MapSample).ToList(),
+            TrainingJobs = docType.TrainingJobs.OrderByDescending(t => t.CompletedAt ?? t.CreatedAt).Select(MapTraining).ToList()
+        };
+
+    private static object MapTemplate(MockTemplate template)
+        => new
+        {
+            template.Id,
+            template.DocumentTypeId,
+            template.Version,
+            template.Description,
+            template.AnchorsJson,
+            template.FieldsJson,
+            template.IsActive,
+            template.UpdatedAt,
+            LastTest = template.LastTest is null ? null : MapTemplateTest(template.LastTest)
+        };
+
+    private static object MapTemplateTest(TemplateTestResult result)
+        => new
+        {
+            result.SampleId,
+            result.SampleFileName,
+            result.Passed,
+            result.Summary,
+            result.Fields,
+            result.TestedAt
+        };
+
+    private static object MapSampler(MockSampler sampler)
+        => new
+        {
+            sampler.Id,
+            sampler.DocumentTypeId,
+            sampler.Code,
+            sampler.Name,
+            sampler.Description,
+            sampler.Fields,
+            sampler.IsActive,
+            sampler.UpdatedAt
+        };
+
+    private static object MapSample(MockSample sample)
+        => new
+        {
+            sample.Id,
+            sample.DocumentTypeId,
+            sample.FileName,
+            sample.UploadedBy,
+            sample.UploadedAt,
+            sample.UpdatedAt,
+            sample.Status,
+            sample.IsLabeled,
+            sample.PreviewUrl,
+            sample.OcrPreview,
+            sample.LabeledText,
+            sample.Fields,
+            sample.SuggestedFields,
+            sample.Notes
+        };
+
+    private static object MapTraining(MockTrainingJob job)
+        => new
+        {
+            job.Id,
+            job.DocumentTypeId,
+            job.Mode,
+            job.Status,
+            job.CreatedAt,
+            job.CompletedAt,
+            job.Summary
+        };
+}

--- a/src/Ocr.Api/Mock/AdminMockStore.cs
+++ b/src/Ocr.Api/Mock/AdminMockStore.cs
@@ -1,0 +1,632 @@
+namespace Ocr.Api.Mock;
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ocr.Core;
+
+public sealed class AdminMockStore
+{
+    private readonly List<MockDocumentType> _docTypes = new();
+    private int _nextDocTypeId = 1;
+    private int _nextSampleId = 1;
+    private int _nextTemplateId = 1;
+    private int _nextSamplerId = 1;
+    private int _nextTrainingJobId = 1;
+
+    public AdminMockStore()
+    {
+        Seed();
+    }
+
+    public IReadOnlyList<MockDocumentType> GetDocTypes() => _docTypes;
+
+    public MockDocumentType? FindDocType(int id) => _docTypes.FirstOrDefault(dt => dt.Id == id);
+
+    public MockSample? FindSample(int id) => _docTypes.SelectMany(dt => dt.Samples).FirstOrDefault(s => s.Id == id);
+
+    public MockTemplate? FindTemplate(int id) => _docTypes.SelectMany(dt => dt.Templates).FirstOrDefault(t => t.Id == id);
+
+    public MockSampler? FindSampler(int id) => _docTypes.SelectMany(dt => dt.Samplers).FirstOrDefault(s => s.Id == id);
+
+    public MockTrainingJob? FindTrainingJob(int id) => _docTypes.SelectMany(dt => dt.TrainingJobs).FirstOrDefault(t => t.Id == id);
+
+    public MockDocumentType CreateDocType(DocTypeUpsertRequest request)
+    {
+        var docType = new MockDocumentType
+        {
+            Id = _nextDocTypeId++,
+            Code = request.Code.Trim(),
+            Name = request.Name.Trim(),
+            Description = request.Description?.Trim(),
+            PreferredMode = ParseMode(request.PreferredMode),
+            SchemaJson = request.SchemaJson?.Trim(),
+            OcrConfigJson = request.OcrConfigJson?.Trim(),
+            OnnxConfigJson = request.OnnxConfigJson?.Trim(),
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        _docTypes.Add(docType);
+        return docType;
+    }
+
+    public MockDocumentType UpdateDocType(int id, DocTypeUpsertRequest request)
+    {
+        var docType = FindDocType(id) ?? throw new InvalidOperationException("Document type not found");
+
+        docType.Name = request.Name.Trim();
+        docType.Description = request.Description?.Trim();
+        docType.PreferredMode = ParseMode(request.PreferredMode);
+        docType.SchemaJson = NormalizeOrNull(request.SchemaJson);
+        docType.OcrConfigJson = NormalizeOrNull(request.OcrConfigJson);
+        docType.OnnxConfigJson = NormalizeOrNull(request.OnnxConfigJson);
+        docType.UpdatedAt = DateTimeOffset.UtcNow;
+        return docType;
+    }
+
+    public MockTemplate CreateTemplate(int docTypeId, TemplateUpsertRequest request)
+    {
+        var docType = FindDocType(docTypeId) ?? throw new InvalidOperationException("Document type not found");
+        var template = new MockTemplate
+        {
+            Id = _nextTemplateId++,
+            DocumentTypeId = docTypeId,
+            Version = string.IsNullOrWhiteSpace(request.Version) ? $"v{docType.Templates.Count + 1}" : request.Version.Trim(),
+            Description = request.Description?.Trim(),
+            AnchorsJson = string.IsNullOrWhiteSpace(request.AnchorsJson) ? "{}" : request.AnchorsJson,
+            FieldsJson = string.IsNullOrWhiteSpace(request.FieldsJson) ? "{}" : request.FieldsJson,
+            IsActive = request.IsActive,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        if (template.IsActive)
+        {
+            foreach (var tpl in docType.Templates)
+            {
+                tpl.IsActive = false;
+            }
+        }
+
+        docType.Templates.Add(template);
+        docType.UpdatedAt = template.UpdatedAt;
+        return template;
+    }
+
+    public MockTemplate UpdateTemplate(int templateId, TemplateUpsertRequest request)
+    {
+        var template = FindTemplate(templateId) ?? throw new InvalidOperationException("Template not found");
+        var docType = FindDocType(template.DocumentTypeId) ?? throw new InvalidOperationException("Document type not found");
+
+        template.Description = request.Description?.Trim();
+        template.Version = string.IsNullOrWhiteSpace(request.Version) ? template.Version : request.Version.Trim();
+        template.AnchorsJson = string.IsNullOrWhiteSpace(request.AnchorsJson) ? "{}" : request.AnchorsJson;
+        template.FieldsJson = string.IsNullOrWhiteSpace(request.FieldsJson) ? "{}" : request.FieldsJson;
+        template.IsActive = request.IsActive;
+        template.UpdatedAt = DateTimeOffset.UtcNow;
+
+        if (template.IsActive)
+        {
+            foreach (var tpl in docType.Templates)
+            {
+                if (tpl.Id != template.Id)
+                {
+                    tpl.IsActive = false;
+                }
+            }
+        }
+
+        docType.UpdatedAt = template.UpdatedAt;
+        return template;
+    }
+
+    public TemplateTestResult TestTemplate(int docTypeId, int templateId, TemplateTestRequest request)
+    {
+        var docType = FindDocType(docTypeId) ?? throw new InvalidOperationException("Document type not found");
+        var template = docType.Templates.FirstOrDefault(t => t.Id == templateId) ?? throw new InvalidOperationException("Template not found");
+        var sample = docType.Samples.FirstOrDefault(s => s.Id == request.SampleId) ?? throw new InvalidOperationException("Sample not found");
+
+        var detectedFields = sample.Fields.Count > 0 ? new Dictionary<string, string>(sample.Fields)
+            : sample.SuggestedFields is not null ? new Dictionary<string, string>(sample.SuggestedFields)
+            : new Dictionary<string, string>();
+
+        var result = new TemplateTestResult
+        {
+            SampleId = sample.Id,
+            SampleFileName = sample.FileName,
+            Passed = detectedFields.Count > 0,
+            Summary = detectedFields.Count > 0
+                ? $"Khớp {detectedFields.Count} trường trên mẫu {sample.FileName}"
+                : "Chưa bắt được trường nào, cần rà soát anchor/regex",
+            Fields = detectedFields,
+            TestedAt = DateTimeOffset.UtcNow
+        };
+
+        template.LastTest = result;
+        template.UpdatedAt = result.TestedAt;
+        docType.UpdatedAt = result.TestedAt;
+        return result;
+    }
+
+    public MockSampler CreateSampler(int docTypeId, SamplerUpsertRequest request)
+    {
+        var docType = FindDocType(docTypeId) ?? throw new InvalidOperationException("Document type not found");
+        var sampler = new MockSampler
+        {
+            Id = _nextSamplerId++,
+            DocumentTypeId = docTypeId,
+            Code = string.IsNullOrWhiteSpace(request.Code) ? $"SAMPLER_{_nextSamplerId}" : request.Code.Trim().ToUpperInvariant(),
+            Name = string.IsNullOrWhiteSpace(request.Name) ? "Sampler mới" : request.Name.Trim(),
+            Description = request.Description?.Trim(),
+            Fields = request.Fields?.Where(f => !string.IsNullOrWhiteSpace(f)).Select(f => f.Trim()).Distinct(StringComparer.OrdinalIgnoreCase).ToList() ?? new List<string>(),
+            IsActive = request.IsActive,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        docType.Samplers.Add(sampler);
+        docType.UpdatedAt = sampler.UpdatedAt;
+        return sampler;
+    }
+
+    public MockSampler UpdateSampler(int samplerId, SamplerUpsertRequest request)
+    {
+        var sampler = FindSampler(samplerId) ?? throw new InvalidOperationException("Sampler not found");
+        sampler.Name = string.IsNullOrWhiteSpace(request.Name) ? sampler.Name : request.Name.Trim();
+        sampler.Description = request.Description?.Trim();
+        sampler.Fields = request.Fields?.Where(f => !string.IsNullOrWhiteSpace(f)).Select(f => f.Trim()).Distinct(StringComparer.OrdinalIgnoreCase).ToList() ?? new List<string>();
+        sampler.IsActive = request.IsActive;
+        sampler.UpdatedAt = DateTimeOffset.UtcNow;
+
+        var docType = FindDocType(sampler.DocumentTypeId);
+        if (docType is not null)
+        {
+            docType.UpdatedAt = sampler.UpdatedAt;
+        }
+
+        return sampler;
+    }
+
+    public MockSample CreateSample(int docTypeId, SampleCreateRequest request)
+    {
+        var docType = FindDocType(docTypeId) ?? throw new InvalidOperationException("Document type not found");
+        var sample = new MockSample
+        {
+            Id = _nextSampleId++,
+            DocumentTypeId = docTypeId,
+            FileName = string.IsNullOrWhiteSpace(request.FileName) ? $"sample_{_nextSampleId}.jpg" : request.FileName.Trim(),
+            UploadedBy = string.IsNullOrWhiteSpace(request.UploadedBy) ? "admin" : request.UploadedBy.Trim(),
+            UploadedAt = DateTimeOffset.UtcNow,
+            PreviewUrl = SamplePreviewPlaceholders[_nextSampleId % SamplePreviewPlaceholders.Length],
+            Status = "Uploaded",
+            OcrPreview = "Giấy tờ chưa qua gán nhãn. Vui lòng mở màn hình labeling để hoàn tất.",
+            SuggestedFields = new Dictionary<string, string>
+            {
+                ["id"] = "001099002233",
+                ["name"] = "Nguyen Van Demo",
+                ["dob"] = "12/03/1992"
+            }
+        };
+
+        docType.Samples.Insert(0, sample);
+        docType.UpdatedAt = sample.UploadedAt;
+        return sample;
+    }
+
+    public MockSample UpdateSampleLabel(int sampleId, SampleLabelRequest request)
+    {
+        var sample = FindSample(sampleId) ?? throw new InvalidOperationException("Sample not found");
+        sample.LabeledText = request.LabeledText?.Trim();
+        sample.Fields = request.Fields ?? new Dictionary<string, string>();
+        sample.Notes = request.Notes?.Trim();
+        sample.IsLabeled = sample.Fields.Count > 0 || !string.IsNullOrWhiteSpace(sample.LabeledText);
+        sample.Status = sample.IsLabeled ? "Labeled" : sample.Status;
+        sample.UpdatedAt = DateTimeOffset.UtcNow;
+
+        var docType = FindDocType(sample.DocumentTypeId);
+        if (docType is not null)
+        {
+            docType.UpdatedAt = sample.UpdatedAt;
+        }
+
+        return sample;
+    }
+
+    public MockTrainingJob TriggerTraining(int docTypeId, TrainingRequest request)
+    {
+        var docType = FindDocType(docTypeId) ?? throw new InvalidOperationException("Document type not found");
+        var job = new MockTrainingJob
+        {
+            Id = _nextTrainingJobId++,
+            DocumentTypeId = docTypeId,
+            Mode = string.IsNullOrWhiteSpace(request.Mode) ? "FAST" : request.Mode.Trim().ToUpperInvariant(),
+            Status = "Completed",
+            CreatedAt = DateTimeOffset.UtcNow,
+            CompletedAt = DateTimeOffset.UtcNow.AddMinutes(5),
+            Summary = string.IsNullOrWhiteSpace(request.Notes)
+                ? "Đã tối ưu whitelist & psm dựa trên 12 mẫu gán nhãn. CER giảm 4%."
+                : request.Notes.Trim()
+        };
+
+        docType.TrainingJobs.Insert(0, job);
+        docType.UpdatedAt = job.CompletedAt ?? job.CreatedAt;
+        return job;
+    }
+
+    private static string? NormalizeOrNull(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static OcrMode ParseMode(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return OcrMode.Auto;
+        }
+
+        return Enum.TryParse<OcrMode>(value, true, out var mode) ? mode : OcrMode.Auto;
+    }
+
+    private void Seed()
+    {
+        var cccdFull = new MockDocumentType
+        {
+            Id = _nextDocTypeId++,
+            Code = "CCCD_FULL",
+            Name = "Căn cước công dân (2 mặt)",
+            Description = "Áp dụng cho bản scan hai mặt CCCD 2021.",
+            PreferredMode = OcrMode.Fast,
+            SchemaJson = "{\n  \"fields\": [\"id\", \"name\", \"dob\", \"address\"]\n}",
+            OcrConfigJson = "{\n  \"psm\": 6,\n  \"dpi\": 300\n}",
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-20),
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-2)
+        };
+
+        cccdFull.Templates.Add(new MockTemplate
+        {
+            Id = _nextTemplateId++,
+            DocumentTypeId = cccdFull.Id,
+            Version = "v1",
+            Description = "Regex cơ bản cho số định danh và ngày sinh.",
+            AnchorsJson = "{\n  \"header\": \"CAN CUOC CONG DAN\"\n}",
+            FieldsJson = "{\n  \"id\": { \"regex\": \"[0-9]{12}\" },\n  \"dob\": { \"regex\": \"[0-9]{2}\\/[0-9]{2}\\/[0-9]{4}\" }\n}",
+            IsActive = true,
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-3)
+        });
+
+        cccdFull.Templates.Add(new MockTemplate
+        {
+            Id = _nextTemplateId++,
+            DocumentTypeId = cccdFull.Id,
+            Version = "v1.1",
+            Description = "Bổ sung regex địa chỉ.",
+            AnchorsJson = "{\n  \"header\": \"CONG HOA XA HOI\"\n}",
+            FieldsJson = "{\n  \"address\": { \"regex\": \"([A-Z\\s]+),\\s*(TP|Tinh)\" }\n}",
+            IsActive = false,
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-6)
+        });
+
+        cccdFull.Samplers.Add(new MockSampler
+        {
+            Id = _nextSamplerId++,
+            DocumentTypeId = cccdFull.Id,
+            Code = "CCCD_FULL",
+            Name = "Bộ đầy đủ",
+            Description = "Bao gồm tất cả trường bắt buộc cho tích hợp core banking.",
+            Fields = new List<string> { "id", "name", "dob", "address" },
+            IsActive = true,
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-10)
+        });
+
+        cccdFull.Samplers.Add(new MockSampler
+        {
+            Id = _nextSamplerId++,
+            DocumentTypeId = cccdFull.Id,
+            Code = "CCCD_MINI",
+            Name = "Bộ rút gọn",
+            Description = "Chỉ lấy số định danh và họ tên.",
+            Fields = new List<string> { "id", "name" },
+            IsActive = false,
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-8)
+        });
+
+        var sample1 = new MockSample
+        {
+            Id = _nextSampleId++,
+            DocumentTypeId = cccdFull.Id,
+            FileName = "cccd_front_demo.jpg",
+            UploadedBy = "thu.tran",
+            UploadedAt = DateTimeOffset.UtcNow.AddDays(-7),
+            PreviewUrl = SamplePreviewPlaceholders[1],
+            Status = "Labeled",
+            OcrPreview = "CAN CUOC CONG DAN\nSO: 001099002233\nHo ten: NGUYEN VAN DEMO\nNgay sinh: 12/03/1992",
+            LabeledText = "CAN CUOC CONG DAN...",
+            Fields = new Dictionary<string, string>
+            {
+                ["id"] = "001099002233",
+                ["name"] = "Nguyễn Văn Demo",
+                ["dob"] = "12/03/1992",
+                ["address"] = "Phường 1, Quận 3"
+            },
+            IsLabeled = true,
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-5)
+        };
+
+        var sample2 = new MockSample
+        {
+            Id = _nextSampleId++,
+            DocumentTypeId = cccdFull.Id,
+            FileName = "cccd_back_demo.jpg",
+            UploadedBy = "thu.tran",
+            UploadedAt = DateTimeOffset.UtcNow.AddDays(-6),
+            PreviewUrl = SamplePreviewPlaceholders[2],
+            Status = "Pending",
+            OcrPreview = "Noi thuong tru: 12 Tran Hung Dao, Q1",
+            SuggestedFields = new Dictionary<string, string>
+            {
+                ["address"] = "12 Trần Hưng Đạo, Q1"
+            },
+            IsLabeled = false,
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-6)
+        };
+
+        cccdFull.Samples.Add(sample1);
+        cccdFull.Samples.Add(sample2);
+
+        cccdFull.TrainingJobs.Add(new MockTrainingJob
+        {
+            Id = _nextTrainingJobId++,
+            DocumentTypeId = cccdFull.Id,
+            Mode = "FAST",
+            Status = "Completed",
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-4),
+            CompletedAt = DateTimeOffset.UtcNow.AddDays(-4).AddHours(1),
+            Summary = "Tối ưu whitelist cho số định danh. CER giảm 3% so với baseline."
+        });
+
+        var hoKhau = new MockDocumentType
+        {
+            Id = _nextDocTypeId++,
+            Code = "HO_KHAU",
+            Name = "Sổ hộ khẩu",
+            Description = "Ảnh chụp sổ hộ khẩu truyền thống",
+            PreferredMode = OcrMode.Enhanced,
+            SchemaJson = "{\n  \"fields\": [\"householdId\", \"owner\", \"address\"]\n}",
+            OcrConfigJson = "{\n  \"contrast\": \"clahe\",\n  \"denoise\": true\n}",
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-40),
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-12)
+        };
+
+        hoKhau.Templates.Add(new MockTemplate
+        {
+            Id = _nextTemplateId++,
+            DocumentTypeId = hoKhau.Id,
+            Version = "v1",
+            Description = "Template beta cho hộ khẩu",
+            AnchorsJson = "{\n  \"header\": \"SO HO KHAU\"\n}",
+            FieldsJson = "{\n  \"owner\": { \"regex\": \"Chu ho: (.*)\" }\n}",
+            IsActive = true,
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-15)
+        });
+
+        hoKhau.Samplers.Add(new MockSampler
+        {
+            Id = _nextSamplerId++,
+            DocumentTypeId = hoKhau.Id,
+            Code = "HK_CORE",
+            Name = "Thông tin lõi",
+            Fields = new List<string> { "householdId", "owner" },
+            IsActive = true,
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-14)
+        });
+
+        hoKhau.Samples.Add(new MockSample
+        {
+            Id = _nextSampleId++,
+            DocumentTypeId = hoKhau.Id,
+            FileName = "ho_khau_demo.jpg",
+            UploadedBy = "lam.nguyen",
+            UploadedAt = DateTimeOffset.UtcNow.AddDays(-13),
+            PreviewUrl = SamplePreviewPlaceholders[3],
+            Status = "Labeled",
+            OcrPreview = "SO HO KHAU\nChu ho: TRAN VAN A",
+            LabeledText = "SO HO KHAU...",
+            Fields = new Dictionary<string, string>
+            {
+                ["householdId"] = "123456789",
+                ["owner"] = "Trần Văn A",
+                ["address"] = "123 Lê Lợi, Đống Đa"
+            },
+            IsLabeled = true,
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-10)
+        });
+
+        hoKhau.TrainingJobs.Add(new MockTrainingJob
+        {
+            Id = _nextTrainingJobId++,
+            DocumentTypeId = hoKhau.Id,
+            Mode = "ENHANCED",
+            Status = "Completed",
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-11),
+            CompletedAt = DateTimeOffset.UtcNow.AddDays(-11).AddHours(2),
+            Summary = "Fine-tune PP-OCR threshold, cải thiện recall anchor."
+        });
+
+        var cccdId = new MockDocumentType
+        {
+            Id = _nextDocTypeId++,
+            Code = "CCCD_ID",
+            Name = "CCCD mặt trước",
+            Description = "Chỉ nhận dạng mặt trước CCCD",
+            PreferredMode = OcrMode.Fast,
+            SchemaJson = "{\n  \"fields\": [\"id\", \"name\"]\n}",
+            CreatedAt = DateTimeOffset.UtcNow.AddDays(-5),
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-2)
+        };
+
+        cccdId.Samples.Add(new MockSample
+        {
+            Id = _nextSampleId++,
+            DocumentTypeId = cccdId.Id,
+            FileName = "cccd_front_light.jpg",
+            UploadedBy = "minh.pham",
+            UploadedAt = DateTimeOffset.UtcNow.AddDays(-3),
+            PreviewUrl = SamplePreviewPlaceholders[4],
+            Status = "Pending",
+            OcrPreview = "SO: 012345678901\nHo ten: LE THI B",
+            SuggestedFields = new Dictionary<string, string>
+            {
+                ["id"] = "012345678901",
+                ["name"] = "Lê Thị B"
+            },
+            IsLabeled = false,
+            UpdatedAt = DateTimeOffset.UtcNow.AddDays(-3)
+        });
+
+        _docTypes.Add(cccdFull);
+        _docTypes.Add(hoKhau);
+        _docTypes.Add(cccdId);
+    }
+
+    private static readonly string[] SamplePreviewPlaceholders =
+    {
+        "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='480' height='320'><rect width='480' height='320' fill='%23f2f4f8'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-family='sans-serif' font-size='24' fill='%23555'>Sample</text></svg>",
+        "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='480' height='320'><rect width='480' height='320' fill='%23e8f0ff'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-family='sans-serif' font-size='24' fill='%233366ff'>CCCD Front</text></svg>",
+        "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='480' height='320'><rect width='480' height='320' fill='%23fff4e5'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-family='sans-serif' font-size='24' fill='%23ff6600'>CCCD Back</text></svg>",
+        "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='480' height='320'><rect width='480' height='320' fill='%23f0fff4'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-family='sans-serif' font-size='24' fill='%2300aa55'>Hộ khẩu</text></svg>",
+        "data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='480' height='320'><rect width='480' height='320' fill='%23f9f0ff'/><text x='50%' y='50%' dominant-baseline='middle' text-anchor='middle' font-family='sans-serif' font-size='24' fill='%238700d7'>CCCD Light</text></svg>"
+    };
+}
+
+public sealed class MockDocumentType
+{
+    public int Id { get; set; }
+    public string Code { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public OcrMode PreferredMode { get; set; } = OcrMode.Auto;
+    public string? SchemaJson { get; set; }
+    public string? OcrConfigJson { get; set; }
+    public string? OnnxConfigJson { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+    public List<MockTemplate> Templates { get; } = new();
+    public List<MockSampler> Samplers { get; } = new();
+    public List<MockSample> Samples { get; } = new();
+    public List<MockTrainingJob> TrainingJobs { get; } = new();
+}
+
+public sealed class MockTemplate
+{
+    public int Id { get; set; }
+    public int DocumentTypeId { get; set; }
+    public string Version { get; set; } = "v1";
+    public string? Description { get; set; }
+    public string AnchorsJson { get; set; } = "{}";
+    public string FieldsJson { get; set; } = "{}";
+    public bool IsActive { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+    public TemplateTestResult? LastTest { get; set; }
+}
+
+public sealed class MockSampler
+{
+    public int Id { get; set; }
+    public int DocumentTypeId { get; set; }
+    public string Code { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public List<string> Fields { get; set; } = new();
+    public bool IsActive { get; set; }
+    public DateTimeOffset UpdatedAt { get; set; }
+}
+
+public sealed class MockSample
+{
+    public int Id { get; set; }
+    public int DocumentTypeId { get; set; }
+    public string FileName { get; set; } = string.Empty;
+    public string UploadedBy { get; set; } = "admin";
+    public DateTimeOffset UploadedAt { get; set; }
+    public DateTimeOffset? UpdatedAt { get; set; }
+    public string Status { get; set; } = "Pending";
+    public bool IsLabeled { get; set; }
+    public string? PreviewUrl { get; set; }
+    public string? OcrPreview { get; set; }
+    public string? LabeledText { get; set; }
+    public Dictionary<string, string> Fields { get; set; } = new();
+    public Dictionary<string, string>? SuggestedFields { get; set; }
+    public string? Notes { get; set; }
+}
+
+public sealed class MockTrainingJob
+{
+    public int Id { get; set; }
+    public int DocumentTypeId { get; set; }
+    public string Mode { get; set; } = "FAST";
+    public string Status { get; set; } = "Completed";
+    public DateTimeOffset CreatedAt { get; set; }
+    public DateTimeOffset? CompletedAt { get; set; }
+    public string Summary { get; set; } = string.Empty;
+}
+
+public sealed class TemplateTestResult
+{
+    public int SampleId { get; set; }
+    public string SampleFileName { get; set; } = string.Empty;
+    public bool Passed { get; set; }
+    public string Summary { get; set; } = string.Empty;
+    public Dictionary<string, string> Fields { get; set; } = new();
+    public DateTimeOffset TestedAt { get; set; }
+}
+
+public sealed class DocTypeUpsertRequest
+{
+    public string Code { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string PreferredMode { get; set; } = "AUTO";
+    public string? SchemaJson { get; set; }
+    public string? OcrConfigJson { get; set; }
+    public string? OnnxConfigJson { get; set; }
+}
+
+public sealed class TemplateUpsertRequest
+{
+    public string Version { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public string AnchorsJson { get; set; } = "{}";
+    public string FieldsJson { get; set; } = "{}";
+    public bool IsActive { get; set; }
+}
+
+public sealed class TemplateTestRequest
+{
+    public int SampleId { get; set; }
+}
+
+public sealed class SamplerUpsertRequest
+{
+    public string Code { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public List<string>? Fields { get; set; }
+    public bool IsActive { get; set; }
+}
+
+public sealed class SampleCreateRequest
+{
+    public string FileName { get; set; } = string.Empty;
+    public string UploadedBy { get; set; } = string.Empty;
+}
+
+public sealed class SampleLabelRequest
+{
+    public string? LabeledText { get; set; }
+    public Dictionary<string, string>? Fields { get; set; }
+    public string? Notes { get; set; }
+}
+
+public sealed class TrainingRequest
+{
+    public string Mode { get; set; } = "FAST";
+    public string? Notes { get; set; }
+}

--- a/src/Ocr.Api/wwwroot/admin/admin.css
+++ b/src/Ocr.Api/wwwroot/admin/admin.css
@@ -1,0 +1,487 @@
+:root {
+  --bg: #f6f8fb;
+  --bg-panel: #ffffff;
+  --border: #dbe3f0;
+  --text: #1f2937;
+  --text-muted: #64748b;
+  --accent: #2563eb;
+  --accent-soft: rgba(37, 99, 235, 0.12);
+  --danger: #dc2626;
+  --success: #059669;
+  --radius: 10px;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  color: var(--text);
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+}
+
+.app-shell {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 280px;
+  background: #0f172a;
+  color: #f8fafc;
+  display: flex;
+  flex-direction: column;
+  padding: 24px 20px;
+  box-sizing: border-box;
+}
+
+.sidebar h1 {
+  font-size: 1.25rem;
+  margin: 0 0 24px;
+}
+
+.sidebar nav {
+  flex: 1;
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+.sidebar a,
+.sidebar button.linklike {
+  display: block;
+  color: inherit;
+  text-decoration: none;
+  padding: 8px 12px;
+  border-radius: 8px;
+  margin-bottom: 6px;
+  background: transparent;
+  border: none;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+}
+
+.sidebar a.active,
+.sidebar a:hover,
+.sidebar button.linklike:hover {
+  background: rgba(148, 163, 184, 0.16);
+}
+
+.sidebar .section-title {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(226, 232, 240, 0.7);
+  margin: 24px 0 8px;
+}
+
+.main {
+  flex: 1;
+  padding: 32px 40px;
+  box-sizing: border-box;
+  overflow-y: auto;
+}
+
+.main-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 24px;
+}
+
+.main-header h2 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.main-header .actions {
+  display: flex;
+  gap: 12px;
+}
+
+.button {
+  border: none;
+  border-radius: 8px;
+  padding: 10px 16px;
+  font: inherit;
+  cursor: pointer;
+  background: var(--accent);
+  color: #fff;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.button.secondary {
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--text);
+}
+
+.button.danger {
+  background: var(--danger);
+}
+
+.button:active {
+  transform: translateY(1px);
+  box-shadow: inset 0 1px 3px rgba(15, 23, 42, 0.2);
+}
+
+.button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.panel {
+  background: var(--bg-panel);
+  border-radius: var(--radius);
+  padding: 24px;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.08);
+  margin-bottom: 24px;
+}
+
+.panel h3 {
+  margin-top: 0;
+}
+
+.grid {
+  display: grid;
+  gap: 16px;
+}
+
+.grid.columns-2 {
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.stat-card {
+  background: var(--bg-panel);
+  border-radius: var(--radius);
+  padding: 20px;
+  border: 1px solid var(--border);
+}
+
+.stat-card h4 {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.stat-card strong {
+  display: block;
+  margin-top: 8px;
+  font-size: 1.5rem;
+}
+
+.table-wrapper {
+  background: var(--bg-panel);
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  overflow: hidden;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+thead {
+  background: #f1f5f9;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  color: var(--text-muted);
+}
+
+td,
+th {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+
+tr:last-child td {
+  border-bottom: none;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.badge.success {
+  background: rgba(5, 150, 105, 0.16);
+  color: var(--success);
+}
+
+.badge.danger {
+  background: rgba(220, 38, 38, 0.16);
+  color: var(--danger);
+}
+
+.form-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.form-field label {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.form-field input,
+.form-field select,
+.form-field textarea {
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  padding: 10px 12px;
+  font: inherit;
+  background: #fff;
+  box-sizing: border-box;
+}
+
+.form-field textarea.small {
+  min-height: 120px;
+}
+
+.field-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr auto;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.field-row input {
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  padding: 8px 10px;
+}
+
+.field-row button {
+  padding: 8px 12px;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 48px 16px;
+  color: var(--text-muted);
+}
+
+.toast {
+  position: fixed;
+  right: 32px;
+  bottom: 32px;
+  background: #0f172a;
+  color: #fff;
+  padding: 16px 20px;
+  border-radius: 12px;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.35);
+  animation: fadein 0.3s ease, fadeout 0.3s ease 3.5s forwards;
+}
+
+@keyframes fadein {
+  from { opacity: 0; transform: translateY(16px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes fadeout {
+  to { opacity: 0; transform: translateY(16px); }
+}
+
+.loading-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 80px;
+}
+
+.spinner {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 4px solid rgba(37, 99, 235, 0.25);
+  border-top-color: var(--accent);
+  animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
+.mode-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--accent);
+  font-weight: 600;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+}
+
+.meta-block {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin: 16px 0;
+}
+
+.meta-block span {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.flex-between {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
+.tab-nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 24px 0;
+}
+
+.tab-nav a {
+  padding: 10px 16px;
+  border-radius: 999px;
+  text-decoration: none;
+  background: rgba(15, 23, 42, 0.06);
+  color: var(--text);
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.tab-nav a.active {
+  background: var(--accent);
+  color: #fff;
+}
+
+.sample-preview {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: minmax(280px, 320px) 1fr;
+}
+
+.sample-preview img {
+  width: 100%;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+}
+
+.sample-preview pre {
+  background: #0f172a;
+  color: #f8fafc;
+  padding: 16px;
+  border-radius: var(--radius);
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.badge-outline {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.form-actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.history-list {
+  display: grid;
+  gap: 16px;
+}
+
+.history-item {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  background: var(--bg-panel);
+}
+
+.history-item h4 {
+  margin: 0 0 8px;
+}
+
+.history-item time {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.template-editor {
+  display: grid;
+  gap: 16px;
+}
+
+.template-editor textarea {
+  min-height: 180px;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+}
+
+.inline-hint {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.alert-info {
+  background: rgba(37, 99, 235, 0.1);
+  border: 1px solid rgba(37, 99, 235, 0.25);
+  padding: 16px;
+  border-radius: var(--radius);
+  font-size: 0.9rem;
+  margin-bottom: 16px;
+}
+
+@media (max-width: 960px) {
+  .app-shell {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    width: 100%;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 16px;
+  }
+
+  .sidebar nav {
+    width: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  .sidebar a,
+  .sidebar button.linklike {
+    flex: 1 1 160px;
+  }
+
+  .main {
+    padding: 24px;
+  }
+
+  .sample-preview {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/Ocr.Api/wwwroot/admin/admin.js
+++ b/src/Ocr.Api/wwwroot/admin/admin.js
@@ -1,0 +1,1484 @@
+const API_BASE = '/api/mock';
+
+const state = {
+  docTypes: [],
+  docTypeDetails: {},
+  sampleCache: {},
+  loading: false,
+  toast: null
+};
+
+const uiState = {
+  showCreateDocType: false,
+  sampleFormFor: null,
+  newTemplateFor: null,
+  templateTestSelection: {},
+  newSamplerFor: null
+};
+
+document.addEventListener('DOMContentLoaded', () => {
+  window.addEventListener('hashchange', () => {
+    void handleRouteChange();
+  });
+  void handleRouteChange();
+});
+
+async function handleRouteChange() {
+  const segments = parseHash();
+  if (segments.length === 0) {
+    navigateTo('#/doc-types');
+    return;
+  }
+
+  try {
+    state.loading = true;
+    renderApp();
+
+    if (state.docTypes.length === 0) {
+      await loadDocTypeSummaries();
+    }
+
+    if (segments[0] === 'doc-types' && segments[1]) {
+      const docTypeId = Number(segments[1]);
+      if (!Number.isNaN(docTypeId)) {
+        await ensureDocTypeDetail(docTypeId);
+      }
+    }
+
+    if (segments[0] === 'samples' && segments[1]) {
+      const sampleId = Number(segments[1]);
+      if (!Number.isNaN(sampleId)) {
+        await ensureSample(sampleId);
+      }
+    }
+  } catch (error) {
+    console.error(error);
+    showToast(error instanceof Error ? error.message : 'Đã xảy ra lỗi không xác định');
+  } finally {
+    state.loading = false;
+    renderApp();
+  }
+}
+
+async function loadDocTypeSummaries() {
+  const data = await fetchJson(`${API_BASE}/doc-types`);
+  state.docTypes = Array.isArray(data)
+    ? data.sort((a, b) => new Date(getValue(b, 'UpdatedAt')).getTime() - new Date(getValue(a, 'UpdatedAt')).getTime())
+    : [];
+}
+
+async function ensureDocTypeDetail(id, options = {}) {
+  const { force = false } = options;
+  if (!force && state.docTypeDetails[id]) {
+    return state.docTypeDetails[id];
+  }
+
+  const detail = await fetchJson(`${API_BASE}/doc-types/${id}`);
+  state.docTypeDetails[id] = detail;
+  return detail;
+}
+
+async function ensureSample(sampleId) {
+  if (state.sampleCache[sampleId]) {
+    return state.sampleCache[sampleId];
+  }
+
+  const sample = await fetchJson(`${API_BASE}/samples/${sampleId}`);
+  state.sampleCache[sampleId] = sample;
+  const docTypeId = getValue(sample, 'DocumentTypeId');
+  if (docTypeId) {
+    const docType = state.docTypeDetails[docTypeId];
+    if (docType) {
+      const samples = getValue(docType, 'Samples') || [];
+      const index = samples.findIndex((s) => getValue(s, 'Id') === sampleId);
+      if (index >= 0) {
+        samples[index] = sample;
+      } else {
+        samples.unshift(sample);
+      }
+    }
+  }
+  return sample;
+}
+
+function renderApp() {
+  const root = document.getElementById('app-root');
+  if (!root) {
+    return;
+  }
+
+  const segments = parseHash();
+  const sidebar = renderSidebar(segments);
+  const mainContent = renderMainContent(segments);
+  const toast = state.toast ? `<div class="toast">${escapeHtml(state.toast)}</div>` : '';
+
+  root.innerHTML = `
+    <div class="app-shell">
+      ${sidebar}
+      <main class="main">${mainContent}</main>
+    </div>
+    ${toast}
+  `;
+
+  bindSidebarEvents();
+  bindContentEvents(segments);
+}
+
+function renderSidebar(segments) {
+  const currentDocTypeId = segments[0] === 'doc-types' && segments[1] ? Number(segments[1]) : null;
+  const docTypeLinks = state.docTypes
+    .map((dt) => {
+      const id = getValue(dt, 'Id');
+      const name = getValue(dt, 'Name');
+      const isActive = currentDocTypeId === id;
+      return `<a href="#/doc-types/${id}/overview" class="${isActive ? 'active' : ''}">${escapeHtml(name)}</a>`;
+    })
+    .join('');
+
+  return `
+    <aside class="sidebar">
+      <h1>OCR Suite Admin</h1>
+      <nav>
+        <a href="#/doc-types" class="${segments[0] === 'doc-types' && !segments[1] ? 'active' : ''}">Bảng điều khiển</a>
+        <div class="section-title">Loại tài liệu</div>
+        ${docTypeLinks || '<span class="inline-hint">Chưa có loại tài liệu</span>'}
+        <button class="linklike" id="sidebar-create-doc-type">+ Thêm loại tài liệu</button>
+      </nav>
+    </aside>
+  `;
+}
+
+function renderMainContent(segments) {
+  if (state.loading && state.docTypes.length === 0) {
+    return renderLoading('Đang tải dữ liệu mock...');
+  }
+
+  if (segments[0] === 'doc-types' && !segments[1]) {
+    return renderDocTypeList();
+  }
+
+  if (segments[0] === 'doc-types' && segments[1]) {
+    const docTypeId = Number(segments[1]);
+    const docType = state.docTypeDetails[docTypeId];
+    if (!docType) {
+      return renderLoading('Đang tải chi tiết loại tài liệu...');
+    }
+
+    const tab = segments[2] || 'overview';
+    const extra = segments.slice(3);
+    return renderDocTypeDetail(docType, tab, extra);
+  }
+
+  if (segments[0] === 'samples' && segments[1]) {
+    const sampleId = Number(segments[1]);
+    const sample = state.sampleCache[sampleId] || findSample(sampleId);
+    if (!sample) {
+      return renderLoading('Đang tải dữ liệu mẫu...');
+    }
+    return renderSampleDetail(sample);
+  }
+
+  return `<div class="panel"><p>Không tìm thấy nội dung phù hợp.</p></div>`;
+}
+
+function renderLoading(message) {
+  return `
+    <div class="loading-state">
+      <div class="spinner"></div>
+      <p>${escapeHtml(message)}</p>
+    </div>
+  `;
+}
+
+function renderDocTypeList() {
+  const cards = state.docTypes.map((dt) => {
+    const id = getValue(dt, 'Id');
+    const code = getValue(dt, 'Code');
+    const name = getValue(dt, 'Name');
+    const preferredMode = getValue(dt, 'PreferredMode');
+    const stats = getValue(dt, 'Stats') || {};
+    const activeTemplate = getValue(dt, 'ActiveTemplate');
+    const lastTraining = getValue(dt, 'LastTraining');
+    const updatedAt = formatDateTime(getValue(dt, 'UpdatedAt'));
+
+    return `
+      <div class="panel">
+        <div class="flex-between">
+          <div>
+            <h3>${escapeHtml(name)}</h3>
+            <p class="inline-hint">Mã: ${escapeHtml(code)}</p>
+          </div>
+          <span class="mode-pill">${escapeHtml(preferredMode || 'AUTO')}</span>
+        </div>
+        <div class="meta-block">
+          <span>${stats.Samples ?? 0} mẫu (${stats.Labeled ?? 0} đã gán nhãn)</span>
+          <span>${stats.Templates ?? 0} template</span>
+          <span>${stats.Samplers ?? 0} sampler</span>
+        </div>
+        ${activeTemplate ? `<span class="badge">Template active: ${escapeHtml(activeTemplate)}</span>` : ''}
+        ${lastTraining ? `<p class="inline-hint">Huấn luyện gần nhất: ${formatDateTime(getValue(lastTraining, 'CompletedAt') || getValue(lastTraining, 'CreatedAt'))}</p>` : ''}
+        <div class="form-actions">
+          <a class="button" href="#/doc-types/${id}/overview">Quản lý</a>
+          <button class="button secondary" type="button" data-action="view-doc" data-id="${id}">Xem chi tiết</button>
+        </div>
+        <p class="inline-hint">Cập nhật: ${updatedAt}</p>
+      </div>
+    `;
+  });
+
+  const createForm = uiState.showCreateDocType ? renderDocTypeCreateForm() : '';
+
+  return `
+    <div class="main-header">
+      <h2>Quản lý loại tài liệu</h2>
+      <div class="actions">
+        <button class="button" id="open-create-doc-type">+ Tạo loại tài liệu</button>
+      </div>
+    </div>
+    ${createForm}
+    <div class="grid columns-2">
+      ${cards.join('') || '<div class="empty-state">Chưa có loại tài liệu nào, hãy tạo mới.</div>'}
+    </div>
+  `;
+}
+
+function renderDocTypeCreateForm() {
+  return `
+    <form class="panel" id="create-doc-type-form">
+      <h3>Tạo loại tài liệu mới</h3>
+      <div class="form-grid">
+        <div class="form-field">
+          <label>Mã loại tài liệu</label>
+          <input name="code" placeholder="VD: CCCD_NEW" required />
+        </div>
+        <div class="form-field">
+          <label>Tên hiển thị</label>
+          <input name="name" placeholder="Tên hiển thị" required />
+        </div>
+        <div class="form-field">
+          <label>Chế độ OCR mặc định</label>
+          <select name="preferredMode">
+            <option value="AUTO">Auto</option>
+            <option value="FAST">FAST</option>
+            <option value="ENHANCED">ENHANCED</option>
+          </select>
+        </div>
+        <div class="form-field">
+          <label>Mô tả</label>
+          <textarea name="description" rows="3" placeholder="Ghi chú ngắn" class="small"></textarea>
+        </div>
+        <div class="form-field">
+          <label>Schema JSON</label>
+          <textarea name="schemaJson" class="small" placeholder='{"fields":["id","name"]}'></textarea>
+        </div>
+        <div class="form-field">
+          <label>OCR Config JSON</label>
+          <textarea name="ocrConfigJson" class="small" placeholder='{"psm":6}'></textarea>
+        </div>
+      </div>
+      <div class="form-actions">
+        <button class="button" type="submit">Tạo</button>
+        <button class="button secondary" type="button" id="cancel-create-doc-type">Hủy</button>
+      </div>
+    </form>
+  `;
+}
+
+function renderDocTypeDetail(docType, tab, extra) {
+  const id = getValue(docType, 'Id');
+  const name = getValue(docType, 'Name');
+  const code = getValue(docType, 'Code');
+  const preferredMode = getValue(docType, 'PreferredMode');
+  const description = getValue(docType, 'Description');
+
+  const tabs = [
+    { key: 'overview', label: 'Tổng quan' },
+    { key: 'samples', label: 'Samples' },
+    { key: 'templates', label: 'Templates' },
+    { key: 'samplers', label: 'Samplers' },
+    { key: 'training', label: 'Huấn luyện' }
+  ];
+
+  const tabNav = tabs
+    .map((t) => `<a href="#/doc-types/${id}/${t.key}" class="${tab === t.key ? 'active' : ''}">${t.label}</a>`)
+    .join('');
+
+  let content = '';
+  switch (tab) {
+    case 'samples':
+      content = renderDocTypeSamples(docType);
+      break;
+    case 'templates':
+      content = renderDocTypeTemplates(docType, extra);
+      break;
+    case 'samplers':
+      content = renderDocTypeSamplers(docType);
+      break;
+    case 'training':
+      content = renderDocTypeTraining(docType);
+      break;
+    case 'overview':
+    default:
+      content = renderDocTypeOverview(docType);
+      break;
+  }
+
+  return `
+    <div class="main-header">
+      <div>
+        <h2>${escapeHtml(name)}</h2>
+        <p class="inline-hint">Mã: ${escapeHtml(code)}</p>
+      </div>
+      <div class="actions">
+        <span class="mode-pill">${escapeHtml(preferredMode || 'AUTO')}</span>
+        <button class="button secondary" type="button" id="refresh-doc-type">Làm mới</button>
+        <a class="button" href="#/doc-types/${id}/samples">Xem samples</a>
+      </div>
+    </div>
+    <div class="alert-info">
+      ${escapeHtml(description || 'Chưa có mô tả.')}<br/>
+      <span class="inline-hint">Chọn tab để quản lý chi tiết: sample, template, sampler và huấn luyện.</span>
+    </div>
+    <div class="tab-nav">${tabNav}</div>
+    ${content}
+  `;
+}
+
+function renderDocTypeOverview(docType) {
+  const schema = getValue(docType, 'SchemaJson');
+  const ocrConfig = getValue(docType, 'OcrConfigJson');
+  const createdAt = formatDateTime(getValue(docType, 'CreatedAt'));
+  const updatedAt = formatDateTime(getValue(docType, 'UpdatedAt'));
+  const samples = getValue(docType, 'Samples') || [];
+  const labeled = samples.filter((s) => getValue(s, 'IsLabeled')).length;
+  const templates = getValue(docType, 'Templates') || [];
+  const samplers = getValue(docType, 'Samplers') || [];
+  const lastTraining = (getValue(docType, 'TrainingJobs') || [])[0];
+
+  return `
+    <div class="grid columns-2">
+      <div class="stat-card">
+        <h4>Tổng số mẫu</h4>
+        <strong>${samples.length}</strong>
+        <span class="inline-hint">${labeled} mẫu đã gán nhãn</span>
+      </div>
+      <div class="stat-card">
+        <h4>Templates & Samplers</h4>
+        <strong>${templates.length} template</strong>
+        <span class="inline-hint">${samplers.length} sampler khả dụng</span>
+      </div>
+    </div>
+    <form class="panel" id="doc-type-form" data-doc-id="${getValue(docType, 'Id')}">
+      <h3>Cấu hình loại tài liệu</h3>
+      <div class="form-grid">
+        <div class="form-field">
+          <label>Tên hiển thị</label>
+          <input name="name" value="${escapeAttribute(getValue(docType, 'Name'))}" required />
+        </div>
+        <div class="form-field">
+          <label>Mô tả</label>
+          <textarea name="description" class="small">${escapeHtml(getValue(docType, 'Description') || '')}</textarea>
+        </div>
+        <div class="form-field">
+          <label>Chế độ OCR mặc định</label>
+          <select name="preferredMode">
+            ${['AUTO', 'FAST', 'ENHANCED'].map((mode) => `<option value="${mode}" ${mode === getValue(docType, 'PreferredMode') ? 'selected' : ''}>${mode}</option>`).join('')}
+          </select>
+        </div>
+        <div class="form-field">
+          <label>Schema JSON</label>
+          <textarea name="schemaJson" class="small">${escapeHtml(schema || '')}</textarea>
+        </div>
+        <div class="form-field">
+          <label>OCR Config JSON</label>
+          <textarea name="ocrConfigJson" class="small">${escapeHtml(ocrConfig || '')}</textarea>
+        </div>
+      </div>
+      <div class="form-actions">
+        <button class="button" type="submit">Lưu cấu hình</button>
+      </div>
+      <p class="inline-hint">Tạo: ${createdAt} · Cập nhật: ${updatedAt}</p>
+    </form>
+    ${lastTraining ? renderLastTraining(lastTraining) : ''}
+  `;
+}
+function renderLastTraining(job) {
+  const summary = getValue(job, 'Summary');
+  const created = formatDateTime(getValue(job, 'CreatedAt'));
+  const completed = formatDateTime(getValue(job, 'CompletedAt'));
+  const mode = getValue(job, 'Mode');
+  return `
+    <div class="panel">
+      <h3>Huấn luyện gần nhất</h3>
+      <p><span class="badge-outline">${escapeHtml(mode)}</span> · Bắt đầu: ${created}</p>
+      <p class="inline-hint">Hoàn tất: ${completed}</p>
+      <p>${escapeHtml(summary || '')}</p>
+    </div>
+  `;
+}
+
+function renderDocTypeSamples(docType) {
+  const docTypeId = getValue(docType, 'Id');
+  const samples = getValue(docType, 'Samples') || [];
+  const rows = samples
+    .map((sample) => {
+      const id = getValue(sample, 'Id');
+      const fileName = getValue(sample, 'FileName');
+      const status = getValue(sample, 'Status');
+      const isLabeled = getValue(sample, 'IsLabeled');
+      const uploadedBy = getValue(sample, 'UploadedBy');
+      const uploadedAt = formatDateTime(getValue(sample, 'UploadedAt'));
+      const updatedAt = formatDateTime(getValue(sample, 'UpdatedAt') || getValue(sample, 'UploadedAt'));
+      return `
+        <tr>
+          <td>
+            <strong>${escapeHtml(fileName)}</strong>
+            <div class="inline-hint">Upload bởi ${escapeHtml(uploadedBy)} · ${uploadedAt}</div>
+          </td>
+          <td>${escapeHtml(status)}</td>
+          <td>${isLabeled ? '<span class="badge success">Đã gán nhãn</span>' : '<span class="badge danger">Chưa gán nhãn</span>'}</td>
+          <td>${updatedAt}</td>
+          <td><a class="button secondary" href="#/samples/${id}">Label</a></td>
+        </tr>
+      `;
+    })
+    .join('');
+
+  const createForm = uiState.sampleFormFor === docTypeId ? renderSampleCreateForm(docTypeId) : '';
+
+  return `
+    <div class="panel">
+      <div class="flex-between">
+        <h3>Danh sách mẫu (${samples.length})</h3>
+        <button class="button" type="button" data-action="toggle-create-sample" data-id="${docTypeId}">+ Thêm mẫu</button>
+      </div>
+      ${createForm}
+      ${samples.length ? `
+        <div class="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Tên file</th>
+                <th>Trạng thái</th>
+                <th>Label</th>
+                <th>Cập nhật</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              ${rows}
+            </tbody>
+          </table>
+        </div>
+      ` : '<div class="empty-state">Chưa có mẫu nào, hãy thêm mẫu mới.</div>'}
+    </div>
+  `;
+}
+
+function renderSampleCreateForm(docTypeId) {
+  return `
+    <form class="panel" id="create-sample-form" data-doc-id="${docTypeId}">
+      <div class="form-grid">
+        <div class="form-field">
+          <label>Tên file (giả lập)</label>
+          <input name="fileName" placeholder="sample_demo.jpg" required />
+        </div>
+        <div class="form-field">
+          <label>Người upload</label>
+          <input name="uploadedBy" placeholder="ten.nguoidung" />
+        </div>
+      </div>
+      <div class="form-actions">
+        <button class="button" type="submit">Tạo sample</button>
+        <button class="button secondary" type="button" data-action="cancel-create-sample">Hủy</button>
+      </div>
+    </form>
+  `;
+}
+
+function renderDocTypeTemplates(docType, extra) {
+  const docTypeId = getValue(docType, 'Id');
+  const templates = getValue(docType, 'Templates') || [];
+  const selectedId = extra && extra[0] ? Number(extra[0]) : (templates[0] ? getValue(templates[0], 'Id') : null);
+
+  const rows = templates
+    .map((tpl) => {
+      const id = getValue(tpl, 'Id');
+      const version = getValue(tpl, 'Version');
+      const description = getValue(tpl, 'Description');
+      const updatedAt = formatDateTime(getValue(tpl, 'UpdatedAt'));
+      const isActive = getValue(tpl, 'IsActive');
+      const lastTest = getValue(tpl, 'LastTest');
+      return `
+        <tr>
+          <td><strong>${escapeHtml(version)}</strong><div class="inline-hint">${escapeHtml(description || '')}</div></td>
+          <td>${updatedAt}</td>
+          <td>${isActive ? '<span class="badge success">Active</span>' : '<span class="badge-outline">Inactive</span>'}</td>
+          <td>${lastTest ? escapeHtml(getValue(lastTest, 'Summary')) : '<span class="inline-hint">Chưa test</span>'}</td>
+          <td><a class="button secondary" href="#/doc-types/${docTypeId}/templates/${id}">Chỉnh sửa</a></td>
+        </tr>
+      `;
+    })
+    .join('');
+
+  const selectedTemplate = templates.find((tpl) => getValue(tpl, 'Id') === selectedId);
+  const editor = selectedTemplate ? renderTemplateEditor(docType, selectedTemplate) : '<div class="empty-state">Chọn một template để chỉnh sửa.</div>';
+  const createForm = uiState.newTemplateFor === docTypeId ? renderTemplateCreateForm(docTypeId) : '';
+
+  return `
+    <div class="panel">
+      <div class="flex-between">
+        <h3>Templates (${templates.length})</h3>
+        <button class="button" type="button" data-action="toggle-create-template" data-id="${docTypeId}">+ Template mới</button>
+      </div>
+      ${createForm}
+      ${templates.length ? `
+        <div class="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Phiên bản</th>
+                <th>Cập nhật</th>
+                <th>Trạng thái</th>
+                <th>Kết quả test</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>${rows}</tbody>
+          </table>
+        </div>
+      ` : '<div class="empty-state">Chưa có template nào.</div>'}
+    </div>
+    ${editor}
+  `;
+}
+
+function renderTemplateCreateForm(docTypeId) {
+  return `
+    <form class="panel template-editor" id="create-template-form" data-doc-id="${docTypeId}">
+      <h3>Template mới</h3>
+      <div class="form-grid">
+        <div class="form-field">
+          <label>Phiên bản</label>
+          <input name="version" placeholder="v1.2" />
+        </div>
+        <div class="form-field">
+          <label>Mô tả</label>
+          <input name="description" placeholder="Ghi chú" />
+        </div>
+        <div class="form-field">
+          <label>Trạng thái</label>
+          <select name="isActive">
+            <option value="true">Active</option>
+            <option value="false">Inactive</option>
+          </select>
+        </div>
+      </div>
+      <div class="form-field">
+        <label>Anchors JSON</label>
+        <textarea name="anchorsJson" class="small">{"header":"ANCHOR"}</textarea>
+      </div>
+      <div class="form-field">
+        <label>Fields JSON</label>
+        <textarea name="fieldsJson" class="small">{"id":{"regex":"[0-9]{12}"}}</textarea>
+      </div>
+      <div class="form-actions">
+        <button class="button" type="submit">Tạo template</button>
+        <button class="button secondary" type="button" data-action="cancel-create-template">Hủy</button>
+      </div>
+    </form>
+  `;
+}
+function renderTemplateEditor(docType, template) {
+  const docTypeId = getValue(docType, 'Id');
+  const templateId = getValue(template, 'Id');
+  const samples = getValue(docType, 'Samples') || [];
+  const lastTest = getValue(template, 'LastTest');
+  const testSampleId = uiState.templateTestSelection[templateId] || (lastTest ? getValue(lastTest, 'SampleId') : (samples[0] ? getValue(samples[0], 'Id') : null));
+
+  const sampleOptions = samples
+    .map((sample) => {
+      const id = getValue(sample, 'Id');
+      const label = `${getValue(sample, 'FileName')} · ${getValue(sample, 'Status')}`;
+      return `<option value="${id}" ${id === testSampleId ? 'selected' : ''}>${escapeHtml(label)}</option>`;
+    })
+    .join('');
+
+  return `
+    <form class="panel template-editor" id="template-edit-form" data-template-id="${templateId}" data-doc-id="${docTypeId}">
+      <h3>Chỉnh sửa template ${escapeHtml(getValue(template, 'Version'))}</h3>
+      <div class="form-grid">
+        <div class="form-field">
+          <label>Phiên bản</label>
+          <input name="version" value="${escapeAttribute(getValue(template, 'Version'))}" />
+        </div>
+        <div class="form-field">
+          <label>Mô tả</label>
+          <input name="description" value="${escapeAttribute(getValue(template, 'Description') || '')}" />
+        </div>
+        <div class="form-field">
+          <label>Trạng thái</label>
+          <select name="isActive">
+            <option value="true" ${getValue(template, 'IsActive') ? 'selected' : ''}>Active</option>
+            <option value="false" ${getValue(template, 'IsActive') ? '' : 'selected'}>Inactive</option>
+          </select>
+        </div>
+      </div>
+      <div class="form-field">
+        <label>Anchors JSON</label>
+        <textarea name="anchorsJson" class="small">${escapeHtml(getValue(template, 'AnchorsJson') || '{}')}</textarea>
+      </div>
+      <div class="form-field">
+        <label>Fields JSON</label>
+        <textarea name="fieldsJson" class="small">${escapeHtml(getValue(template, 'FieldsJson') || '{}')}</textarea>
+      </div>
+      <div class="form-actions">
+        <button class="button" type="submit">Lưu template</button>
+        ${samples.length ? `
+          <div class="form-field" style="margin:0">
+            <label>Test trên sample</label>
+            <select name="testSampleId">
+              ${sampleOptions}
+            </select>
+          </div>
+          <button class="button secondary" type="button" id="run-template-test">Chạy test</button>
+        ` : '<span class="inline-hint">Cần tối thiểu một sample để test template.</span>'}
+      </div>
+      ${lastTest ? `
+        <div class="panel" style="margin-top:16px">
+          <h4>Kết quả test gần nhất</h4>
+          <p>${escapeHtml(getValue(lastTest, 'Summary') || '')}</p>
+          <p class="inline-hint">Mẫu: ${escapeHtml(getValue(lastTest, 'SampleFileName') || '')} · ${formatDateTime(getValue(lastTest, 'TestedAt'))}</p>
+          <pre>${escapeHtml(JSON.stringify(getValue(lastTest, 'Fields') || {}, null, 2))}</pre>
+        </div>
+      ` : '<div class="inline-hint">Chưa có kết quả test nào.</div>'}
+    </form>
+  `;
+}
+
+function renderDocTypeSamplers(docType) {
+  const docTypeId = getValue(docType, 'Id');
+  const samplers = getValue(docType, 'Samplers') || [];
+  const createForm = uiState.newSamplerFor === docTypeId ? renderSamplerCreateForm(docTypeId) : '';
+
+  const forms = samplers
+    .map((sampler) => {
+      const samplerId = getValue(sampler, 'Id');
+      const code = getValue(sampler, 'Code');
+      const name = getValue(sampler, 'Name');
+      const description = getValue(sampler, 'Description');
+      const fields = (getValue(sampler, 'Fields') || []).join(', ');
+      const isActive = getValue(sampler, 'IsActive');
+      const updatedAt = formatDateTime(getValue(sampler, 'UpdatedAt'));
+      return `
+        <form class="panel" data-sampler-id="${samplerId}" data-doc-id="${docTypeId}">
+          <h3>${escapeHtml(name)}</h3>
+          <div class="form-grid">
+            <div class="form-field">
+              <label>Mã sampler</label>
+              <input name="code" value="${escapeAttribute(code)}" disabled />
+            </div>
+            <div class="form-field">
+              <label>Tên hiển thị</label>
+              <input name="name" value="${escapeAttribute(name)}" />
+            </div>
+            <div class="form-field">
+              <label>Trạng thái</label>
+              <select name="isActive">
+                <option value="true" ${isActive ? 'selected' : ''}>Active</option>
+                <option value="false" ${isActive ? '' : 'selected'}>Inactive</option>
+              </select>
+            </div>
+          </div>
+          <div class="form-field">
+            <label>Mô tả</label>
+            <textarea name="description" class="small">${escapeHtml(description || '')}</textarea>
+          </div>
+          <div class="form-field">
+            <label>Các trường (phân tách bởi dấu phẩy)</label>
+            <input name="fields" value="${escapeAttribute(fields)}" placeholder="id, name, dob" />
+          </div>
+          <div class="form-actions">
+            <button class="button" type="submit">Lưu sampler</button>
+            <span class="inline-hint">Cập nhật: ${updatedAt}</span>
+          </div>
+        </form>
+      `;
+    })
+    .join('');
+
+  return `
+    <div class="panel">
+      <div class="flex-between">
+        <h3>Samplers (${samplers.length})</h3>
+        <button class="button" type="button" data-action="toggle-create-sampler" data-id="${docTypeId}">+ Sampler mới</button>
+      </div>
+      ${createForm}
+      <div class="history-list">
+        ${forms || '<div class="empty-state">Chưa có sampler nào.</div>'}
+      </div>
+    </div>
+  `;
+}
+
+function renderSamplerCreateForm(docTypeId) {
+  return `
+    <form class="panel" id="create-sampler-form" data-doc-id="${docTypeId}">
+      <h3>Sampler mới</h3>
+      <div class="form-grid">
+        <div class="form-field">
+          <label>Mã sampler</label>
+          <input name="code" placeholder="VD: CCCD_CORE" />
+        </div>
+        <div class="form-field">
+          <label>Tên hiển thị</label>
+          <input name="name" placeholder="Tên sampler" required />
+        </div>
+        <div class="form-field">
+          <label>Trạng thái</label>
+          <select name="isActive">
+            <option value="true">Active</option>
+            <option value="false">Inactive</option>
+          </select>
+        </div>
+      </div>
+      <div class="form-field">
+        <label>Mô tả</label>
+        <textarea name="description" class="small" placeholder="Mục đích sử dụng"></textarea>
+      </div>
+      <div class="form-field">
+        <label>Các trường (phân tách bởi dấu phẩy)</label>
+        <input name="fields" placeholder="id, name, dob" />
+      </div>
+      <div class="form-actions">
+        <button class="button" type="submit">Tạo sampler</button>
+        <button class="button secondary" type="button" data-action="cancel-create-sampler">Hủy</button>
+      </div>
+    </form>
+  `;
+}
+
+function renderDocTypeTraining(docType) {
+  const docTypeId = getValue(docType, 'Id');
+  const jobs = getValue(docType, 'TrainingJobs') || [];
+  const history = jobs
+    .map((job) => {
+      return `
+        <div class="history-item">
+          <h4>${escapeHtml(getValue(job, 'Mode'))} · ${escapeHtml(getValue(job, 'Status'))}</h4>
+          <time>Bắt đầu: ${formatDateTime(getValue(job, 'CreatedAt'))}</time><br/>
+          <time>Hoàn tất: ${formatDateTime(getValue(job, 'CompletedAt'))}</time>
+          <p>${escapeHtml(getValue(job, 'Summary') || '')}</p>
+        </div>
+      `;
+    })
+    .join('');
+
+  return `
+    <form class="panel" id="train-form" data-doc-id="${docTypeId}">
+      <h3>Kích hoạt huấn luyện</h3>
+      <div class="form-grid">
+        <div class="form-field">
+          <label>Chế độ</label>
+          <select name="mode">
+            <option value="FAST">FAST</option>
+            <option value="ENHANCED">ENHANCED</option>
+          </select>
+        </div>
+        <div class="form-field">
+          <label>Ghi chú</label>
+          <textarea name="notes" class="small" placeholder="Mô tả kỳ vọng, ví dụ: Tối ưu whitelist"></textarea>
+        </div>
+      </div>
+      <div class="form-actions">
+        <button class="button" type="submit">Chạy huấn luyện</button>
+      </div>
+    </form>
+    <div class="panel">
+      <h3>Lịch sử huấn luyện</h3>
+      <div class="history-list">
+        ${history || '<div class="empty-state">Chưa có lịch sử huấn luyện.</div>'}
+      </div>
+    </div>
+  `;
+}
+
+function renderSampleDetail(sample) {
+  const sampleId = getValue(sample, 'Id');
+  const docTypeId = getValue(sample, 'DocumentTypeId');
+  const docType = state.docTypeDetails[docTypeId] || state.docTypes.find((dt) => getValue(dt, 'Id') === docTypeId) || null;
+  const docName = docType ? getValue(docType, 'Name') : 'Không xác định';
+  const previewUrl = getValue(sample, 'PreviewUrl');
+  const status = getValue(sample, 'Status');
+  const isLabeled = getValue(sample, 'IsLabeled');
+  const uploadedAt = formatDateTime(getValue(sample, 'UploadedAt'));
+  const updatedAt = formatDateTime(getValue(sample, 'UpdatedAt') || getValue(sample, 'UploadedAt'));
+  const ocrPreview = getValue(sample, 'OcrPreview') || '';
+  const labeledText = getValue(sample, 'LabeledText') || '';
+  const notes = getValue(sample, 'Notes') || '';
+  const suggested = getValue(sample, 'SuggestedFields');
+
+  return `
+    <div class="main-header">
+      <div>
+        <h2>${escapeHtml(getValue(sample, 'FileName'))}</h2>
+        <p class="inline-hint">DocType: ${escapeHtml(docName)} · ID: ${docTypeId}</p>
+      </div>
+      <div class="actions">
+        <a class="button secondary" href="#/doc-types/${docTypeId}/samples">Quay lại samples</a>
+      </div>
+    </div>
+    <div class="panel sample-preview">
+      <div>
+        ${previewUrl ? `<img src="${previewUrl}" alt="Preview" />` : '<div class="empty-state">Không có preview</div>'}
+        <div class="meta-block">
+          <span>Trạng thái: ${escapeHtml(status)}</span>
+          <span>${isLabeled ? '<span class="badge success">Đã gán nhãn</span>' : '<span class="badge danger">Chưa gán nhãn</span>'}</span>
+          <span>Upload: ${uploadedAt}</span>
+          <span>Cập nhật: ${updatedAt}</span>
+        </div>
+      </div>
+      <div>
+        <h3>OCR thô</h3>
+        <pre>${escapeHtml(ocrPreview)}</pre>
+      </div>
+    </div>
+    ${suggested ? `
+      <div class="panel">
+        <h3>Gợi ý trường từ OCR</h3>
+        <pre>${escapeHtml(JSON.stringify(suggested, null, 2))}</pre>
+        <button class="button secondary" type="button" id="apply-suggestion">Áp dụng gợi ý</button>
+      </div>
+    ` : ''}
+    <form class="panel" id="label-form" data-sample-id="${sampleId}" data-doc-id="${docTypeId}">
+      <h3>Gán nhãn mẫu</h3>
+      <div class="form-field">
+        <label>Full text chuẩn hóa</label>
+        <textarea name="labeledText" class="small" placeholder="Nhập full text chuẩn hóa...">${escapeHtml(labeledText)}</textarea>
+      </div>
+      <div class="form-field">
+        <label>Trường dữ liệu</label>
+        <div id="fields-container"></div>
+        <button class="button secondary" type="button" id="add-field">+ Thêm trường</button>
+      </div>
+      <div class="form-field">
+        <label>Ghi chú</label>
+        <textarea name="notes" class="small" placeholder="Ghi chú nội bộ">${escapeHtml(notes)}</textarea>
+      </div>
+      <div class="form-actions">
+        <button class="button" type="submit">Lưu nhãn</button>
+      </div>
+    </form>
+  `;
+}
+function bindSidebarEvents() {
+  const createBtn = document.getElementById('sidebar-create-doc-type');
+  if (createBtn) {
+    createBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      uiState.showCreateDocType = true;
+      navigateTo('#/doc-types');
+    });
+  }
+}
+
+function bindContentEvents(segments) {
+  if (segments[0] === 'doc-types' && !segments[1]) {
+    bindDocTypeListEvents();
+    return;
+  }
+
+  if (segments[0] === 'doc-types' && segments[1]) {
+    const docTypeId = Number(segments[1]);
+    const tab = segments[2] || 'overview';
+    switch (tab) {
+      case 'samples':
+        bindDocTypeSamplesEvents(docTypeId);
+        break;
+      case 'templates':
+        bindDocTypeTemplatesEvents(docTypeId);
+        break;
+      case 'samplers':
+        bindDocTypeSamplersEvents(docTypeId);
+        break;
+      case 'training':
+        bindDocTypeTrainingEvents(docTypeId);
+        break;
+      case 'overview':
+      default:
+        bindDocTypeOverviewEvents(docTypeId);
+        break;
+    }
+    return;
+  }
+
+  if (segments[0] === 'samples' && segments[1]) {
+    const sampleId = Number(segments[1]);
+    bindSampleDetailEvents(sampleId);
+  }
+}
+
+function bindDocTypeListEvents() {
+  const openBtn = document.getElementById('open-create-doc-type');
+  if (openBtn) {
+    openBtn.addEventListener('click', () => {
+      uiState.showCreateDocType = !uiState.showCreateDocType;
+      renderApp();
+    });
+  }
+
+  const cancelBtn = document.getElementById('cancel-create-doc-type');
+  if (cancelBtn) {
+    cancelBtn.addEventListener('click', () => {
+      uiState.showCreateDocType = false;
+      renderApp();
+    });
+  }
+
+  const form = document.getElementById('create-doc-type-form');
+  if (form) {
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const payload = {
+        code: form.code.value.trim(),
+        name: form.name.value.trim(),
+        preferredMode: form.preferredMode.value,
+        description: form.description.value.trim() || null,
+        schemaJson: form.schemaJson.value.trim() || null,
+        ocrConfigJson: form.ocrConfigJson.value.trim() || null
+      };
+
+      try {
+        const created = await fetchJson(`${API_BASE}/doc-types`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+
+        const newId = getValue(created, 'Id');
+        uiState.showCreateDocType = false;
+        state.docTypeDetails[newId] = created;
+        await loadDocTypeSummaries();
+        showToast('Đã tạo loại tài liệu mới');
+        navigateTo(`#/doc-types/${newId}/overview`);
+      } catch (error) {
+        showToast(error instanceof Error ? error.message : 'Không thể tạo docType');
+      }
+    });
+  }
+
+  document.querySelectorAll('button[data-action="view-doc"]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const id = Number(btn.dataset.id);
+      if (!Number.isNaN(id)) {
+        navigateTo(`#/doc-types/${id}/overview`);
+      }
+    });
+  });
+}
+
+function bindDocTypeOverviewEvents(docTypeId) {
+  const refreshBtn = document.getElementById('refresh-doc-type');
+  if (refreshBtn) {
+    refreshBtn.addEventListener('click', async () => {
+      await ensureDocTypeDetail(docTypeId, { force: true });
+      await loadDocTypeSummaries();
+      showToast('Đã làm mới dữ liệu docType');
+    });
+  }
+
+  const form = document.getElementById('doc-type-form');
+  if (form) {
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const payload = {
+        code: state.docTypeDetails[docTypeId]?.Code || state.docTypeDetails[docTypeId]?.code || '',
+        name: form.name.value.trim(),
+        description: form.description.value.trim() || null,
+        preferredMode: form.preferredMode.value,
+        schemaJson: form.schemaJson.value.trim() || null,
+        ocrConfigJson: form.ocrConfigJson.value.trim() || null
+      };
+
+      try {
+        const updated = await fetchJson(`${API_BASE}/doc-types/${docTypeId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+
+        state.docTypeDetails[docTypeId] = updated;
+        await loadDocTypeSummaries();
+        showToast('Đã lưu cấu hình docType');
+        renderApp();
+      } catch (error) {
+        showToast(error instanceof Error ? error.message : 'Không thể cập nhật docType');
+      }
+    });
+  }
+}
+
+function bindDocTypeSamplesEvents(docTypeId) {
+  document.querySelectorAll('button[data-action="toggle-create-sample"]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const id = Number(btn.dataset.id);
+      uiState.sampleFormFor = uiState.sampleFormFor === id ? null : id;
+      renderApp();
+    });
+  });
+
+  const cancelBtn = document.querySelector('button[data-action="cancel-create-sample"]');
+  if (cancelBtn) {
+    cancelBtn.addEventListener('click', () => {
+      uiState.sampleFormFor = null;
+      renderApp();
+    });
+  }
+
+  const form = document.getElementById('create-sample-form');
+  if (form) {
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const payload = {
+        fileName: form.fileName.value.trim(),
+        uploadedBy: form.uploadedBy.value.trim() || 'admin'
+      };
+
+      try {
+        await fetchJson(`${API_BASE}/doc-types/${docTypeId}/samples`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        uiState.sampleFormFor = null;
+        await ensureDocTypeDetail(docTypeId, { force: true });
+        await loadDocTypeSummaries();
+        showToast('Đã tạo sample giả lập');
+        renderApp();
+      } catch (error) {
+        showToast(error instanceof Error ? error.message : 'Không thể tạo sample');
+      }
+    });
+  }
+}
+
+function bindDocTypeTemplatesEvents(docTypeId) {
+  document.querySelectorAll('button[data-action="toggle-create-template"]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const id = Number(btn.dataset.id);
+      uiState.newTemplateFor = uiState.newTemplateFor === id ? null : id;
+      renderApp();
+    });
+  });
+
+  const cancelBtn = document.querySelector('button[data-action="cancel-create-template"]');
+  if (cancelBtn) {
+    cancelBtn.addEventListener('click', () => {
+      uiState.newTemplateFor = null;
+      renderApp();
+    });
+  }
+
+  const createForm = document.getElementById('create-template-form');
+  if (createForm) {
+    createForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const payload = {
+        version: createForm.version.value.trim(),
+        description: createForm.description.value.trim() || null,
+        anchorsJson: createForm.anchorsJson.value,
+        fieldsJson: createForm.fieldsJson.value,
+        isActive: createForm.isActive.value === 'true'
+      };
+
+      try {
+        const created = await fetchJson(`${API_BASE}/doc-types/${docTypeId}/templates`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        const newId = getValue(created, 'Id');
+        uiState.newTemplateFor = null;
+        await ensureDocTypeDetail(docTypeId, { force: true });
+        await loadDocTypeSummaries();
+        showToast('Đã tạo template mới');
+        navigateTo(`#/doc-types/${docTypeId}/templates/${newId}`);
+      } catch (error) {
+        showToast(error instanceof Error ? error.message : 'Không thể tạo template');
+      }
+    });
+  }
+
+  const editForm = document.getElementById('template-edit-form');
+  if (editForm) {
+    const templateId = Number(editForm.dataset.templateId);
+    const select = editForm.querySelector('select[name="testSampleId"]');
+    if (select) {
+      select.addEventListener('change', () => {
+        uiState.templateTestSelection[templateId] = Number(select.value);
+      });
+    }
+
+    editForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const payload = {
+        version: editForm.version.value.trim(),
+        description: editForm.description.value.trim() || null,
+        anchorsJson: editForm.anchorsJson.value,
+        fieldsJson: editForm.fieldsJson.value,
+        isActive: editForm.isActive.value === 'true'
+      };
+
+      try {
+        await fetchJson(`${API_BASE}/templates/${templateId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        await ensureDocTypeDetail(docTypeId, { force: true });
+        await loadDocTypeSummaries();
+        showToast('Đã lưu template');
+        renderApp();
+      } catch (error) {
+        showToast(error instanceof Error ? error.message : 'Không thể cập nhật template');
+      }
+    });
+
+    const testBtn = document.getElementById('run-template-test');
+    if (testBtn) {
+      testBtn.addEventListener('click', async () => {
+        const sampleId = Number(editForm.testSampleId.value);
+        if (!sampleId) {
+          showToast('Chọn sample để test');
+          return;
+        }
+
+        try {
+          await fetchJson(`${API_BASE}/doc-types/${docTypeId}/templates/${templateId}/test`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ sampleId })
+          });
+          await ensureDocTypeDetail(docTypeId, { force: true });
+          showToast('Đã test template');
+          renderApp();
+        } catch (error) {
+          showToast(error instanceof Error ? error.message : 'Test template thất bại');
+        }
+      });
+    }
+  }
+}
+
+function bindDocTypeSamplersEvents(docTypeId) {
+  document.querySelectorAll('button[data-action="toggle-create-sampler"]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const id = Number(btn.dataset.id);
+      uiState.newSamplerFor = uiState.newSamplerFor === id ? null : id;
+      renderApp();
+    });
+  });
+
+  const cancelBtn = document.querySelector('button[data-action="cancel-create-sampler"]');
+  if (cancelBtn) {
+    cancelBtn.addEventListener('click', () => {
+      uiState.newSamplerFor = null;
+      renderApp();
+    });
+  }
+
+  const createForm = document.getElementById('create-sampler-form');
+  if (createForm) {
+    createForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const payload = {
+        code: createForm.code.value.trim(),
+        name: createForm.name.value.trim(),
+        description: createForm.description.value.trim() || null,
+        fields: createForm.fields.value.split(',').map((v) => v.trim()).filter(Boolean),
+        isActive: createForm.isActive.value === 'true'
+      };
+
+      try {
+        await fetchJson(`${API_BASE}/doc-types/${docTypeId}/samplers`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        uiState.newSamplerFor = null;
+        await ensureDocTypeDetail(docTypeId, { force: true });
+        await loadDocTypeSummaries();
+        showToast('Đã tạo sampler mới');
+        renderApp();
+      } catch (error) {
+        showToast(error instanceof Error ? error.message : 'Không thể tạo sampler');
+      }
+    });
+  }
+
+  document.querySelectorAll('form[data-sampler-id]').forEach((form) => {
+    const samplerId = Number(form.dataset.samplerId);
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const payload = {
+        name: form.name.value.trim(),
+        description: form.description.value.trim() || null,
+        fields: form.fields.value.split(',').map((v) => v.trim()).filter(Boolean),
+        isActive: form.isActive.value === 'true'
+      };
+
+      try {
+        await fetchJson(`${API_BASE}/samplers/${samplerId}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        await ensureDocTypeDetail(docTypeId, { force: true });
+        await loadDocTypeSummaries();
+        showToast('Đã lưu sampler');
+        renderApp();
+      } catch (error) {
+        showToast(error instanceof Error ? error.message : 'Không thể cập nhật sampler');
+      }
+    });
+  });
+}
+
+function bindDocTypeTrainingEvents(docTypeId) {
+  const form = document.getElementById('train-form');
+  if (form) {
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const payload = {
+        mode: form.mode.value,
+        notes: form.notes.value.trim() || null
+      };
+
+      try {
+        await fetchJson(`${API_BASE}/doc-types/${docTypeId}/train`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        await ensureDocTypeDetail(docTypeId, { force: true });
+        await loadDocTypeSummaries();
+        showToast('Đã ghi nhận phiên huấn luyện giả lập');
+        renderApp();
+      } catch (error) {
+        showToast(error instanceof Error ? error.message : 'Không thể kích hoạt huấn luyện');
+      }
+    });
+  }
+}
+
+function bindSampleDetailEvents(sampleId) {
+  const sample = state.sampleCache[sampleId] || findSample(sampleId);
+  if (!sample) {
+    return;
+  }
+
+  const container = document.getElementById('fields-container');
+  if (container) {
+    populateFieldRows(container, sample);
+
+    container.addEventListener('click', (event) => {
+      const target = event.target;
+      if (target instanceof HTMLButtonElement && target.dataset.action === 'remove-field') {
+        event.preventDefault();
+        target.parentElement?.remove();
+      }
+    });
+  }
+
+  const addFieldBtn = document.getElementById('add-field');
+  if (addFieldBtn && container) {
+    addFieldBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      appendFieldRow(container, '', '');
+    });
+  }
+
+  const applySuggestionBtn = document.getElementById('apply-suggestion');
+  if (applySuggestionBtn && container) {
+    applySuggestionBtn.addEventListener('click', (event) => {
+      event.preventDefault();
+      const suggestion = getValue(sample, 'SuggestedFields') || {};
+      populateFieldRows(container, sample, suggestion);
+      showToast('Đã áp dụng gợi ý OCR');
+    });
+  }
+
+  const form = document.getElementById('label-form');
+  if (form && container) {
+    form.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const fields = {};
+      container.querySelectorAll('.field-row').forEach((row) => {
+        const keyInput = row.querySelector('input[name="field-key"]');
+        const valueInput = row.querySelector('input[name="field-value"]');
+        const key = keyInput?.value.trim();
+        const value = valueInput?.value.trim();
+        if (key) {
+          fields[key] = value || '';
+        }
+      });
+
+      const payload = {
+        labeledText: form.labeledText.value.trim() || null,
+        notes: form.notes.value.trim() || null,
+        fields
+      };
+
+      const docTypeId = Number(form.dataset.docId);
+
+      try {
+        const updated = await fetchJson(`${API_BASE}/samples/${sampleId}/label`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        state.sampleCache[sampleId] = updated;
+        await ensureDocTypeDetail(docTypeId, { force: true });
+        await loadDocTypeSummaries();
+        showToast('Đã lưu nhãn sample');
+        renderApp();
+      } catch (error) {
+        showToast(error instanceof Error ? error.message : 'Không thể lưu nhãn');
+      }
+    });
+  }
+}
+
+function navigateTo(hash) {
+  if (window.location.hash !== hash) {
+    window.location.hash = hash;
+  } else {
+    renderApp();
+  }
+}
+
+function parseHash() {
+  const hash = window.location.hash || '';
+  return hash.replace(/^#/, '').split('/').filter(Boolean);
+}
+
+async function fetchJson(url, options = {}) {
+  const response = await fetch(url, options);
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || response.statusText);
+  }
+
+  if (response.status === 204) {
+    return null;
+  }
+
+  const text = await response.text();
+  return text ? JSON.parse(text) : null;
+}
+
+function getValue(obj, key) {
+  if (!obj) {
+    return undefined;
+  }
+
+  if (Object.prototype.hasOwnProperty.call(obj, key)) {
+    return obj[key];
+  }
+
+  const camel = key.charAt(0).toLowerCase() + key.slice(1);
+  if (Object.prototype.hasOwnProperty.call(obj, camel)) {
+    return obj[camel];
+  }
+
+  return undefined;
+}
+
+function escapeHtml(value) {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeAttribute(value) {
+  return escapeHtml(value);
+}
+
+function formatDateTime(value) {
+  if (!value) {
+    return '-';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return String(value);
+  }
+  return date.toLocaleString('vi-VN', {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  });
+}
+
+function findSample(sampleId) {
+  for (const doc of Object.values(state.docTypeDetails)) {
+    const samples = getValue(doc, 'Samples') || [];
+    const found = samples.find((sample) => getValue(sample, 'Id') === sampleId);
+    if (found) {
+      return found;
+    }
+  }
+  return null;
+}
+
+function showToast(message) {
+  state.toast = message;
+  renderApp();
+  setTimeout(() => {
+    if (state.toast === message) {
+      state.toast = null;
+      renderApp();
+    }
+  }, 3600);
+}
+
+function appendFieldRow(container, key = '', value = '') {
+  const row = document.createElement('div');
+  row.className = 'field-row';
+
+  const keyInput = document.createElement('input');
+  keyInput.name = 'field-key';
+  keyInput.placeholder = 'Tên trường (vd: id)';
+  keyInput.value = key;
+
+  const valueInput = document.createElement('input');
+  valueInput.name = 'field-value';
+  valueInput.placeholder = 'Giá trị';
+  valueInput.value = value;
+
+  const removeBtn = document.createElement('button');
+  removeBtn.type = 'button';
+  removeBtn.className = 'button secondary';
+  removeBtn.dataset.action = 'remove-field';
+  removeBtn.textContent = 'Xóa';
+
+  row.append(keyInput, valueInput, removeBtn);
+  container.append(row);
+}
+
+function populateFieldRows(container, sample, override) {
+  const source = override || getValue(sample, 'Fields') || {};
+  container.innerHTML = '';
+  const entries = Object.entries(source);
+  if (entries.length === 0) {
+    appendFieldRow(container, '', '');
+    return;
+  }
+
+  entries.forEach(([key, value]) => appendFieldRow(container, key, value));
+}

--- a/src/Ocr.Api/wwwroot/admin/index.html
+++ b/src/Ocr.Api/wwwroot/admin/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="vi">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OCR Suite Admin Console</title>
+  <link rel="stylesheet" href="admin.css" />
+</head>
+<body>
+  <div class="app-shell" id="app-root">
+    <div class="loading-state">
+      <div class="spinner"></div>
+      <p>Đang tải dữ liệu mock...</p>
+    </div>
+  </div>
+  <script src="admin.js" type="module"></script>
+</body>
+</html>

--- a/src/Ocr.Api/wwwroot/test/index.html
+++ b/src/Ocr.Api/wwwroot/test/index.html
@@ -1,27 +1,87 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="vi">
 <head>
   <meta charset="utf-8" />
-  <title>OCR Suite Test</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>OCR Suite – Test nhanh</title>
   <link rel="stylesheet" href="test.css" />
 </head>
 <body>
-  <h1>OCR Suite – Test UI</h1>
-  <form id="ocr-form" enctype="multipart/form-data">
-    <label>Chọn ảnh/PDF: <input type="file" name="file" required /></label>
-    <label>Mã loại tài liệu (tùy chọn): <input name="docType" placeholder="VD: CCCD_FULL" /></label>
-    <label>Sampler (tùy chọn): <input name="sampler" placeholder="VD: CCCD_ID" /></label>
-    <label>Chế độ OCR:
-      <select name="mode">
-        <option value="AUTO">Auto</option>
-        <option value="FAST">Fast (Tesseract)</option>
-        <option value="ENHANCED">Enhanced (ONNX)</option>
-      </select>
-    </label>
-    <button type="submit">Nhận dạng</button>
-  </form>
-  <h2>Kết quả</h2>
-  <pre id="result"></pre>
+  <main class="container">
+    <header class="hero">
+      <h1>OCR Suite – Test nhanh pipeline</h1>
+      <p>Tải ảnh/PDF để trải nghiệm pipeline AUTO/FAST/ENHANCED. Chọn docType & sampler để xem kết quả trích xuất.</p>
+    </header>
+
+    <section class="card">
+      <form id="ocr-form" enctype="multipart/form-data" class="form-grid">
+        <div class="form-field full">
+          <label for="file-input">Tệp ảnh/PDF</label>
+          <input id="file-input" type="file" name="file" accept="image/*,.pdf" required />
+        </div>
+        <div class="form-field">
+          <label for="docType-input">DocType (tùy chọn)</label>
+          <input id="docType-input" name="docType" placeholder="VD: CCCD_FULL" />
+        </div>
+        <div class="form-field">
+          <label for="sampler-input">Sampler (tùy chọn)</label>
+          <input id="sampler-input" name="sampler" placeholder="VD: CCCD_ID" />
+        </div>
+        <div class="form-field">
+          <label for="mode-select">Chế độ OCR</label>
+          <select id="mode-select" name="mode">
+            <option value="AUTO">AUTO (theo cấu hình docType)</option>
+            <option value="FAST">FAST – Tesseract</option>
+            <option value="ENHANCED">ENHANCED – PP-OCR</option>
+          </select>
+        </div>
+        <div class="actions">
+          <button class="button" type="submit">Nhận dạng ngay</button>
+          <button class="button secondary" type="reset" id="reset-form">Làm mới</button>
+        </div>
+      </form>
+    </section>
+
+    <section class="card hidden" id="result-card">
+      <header class="result-header">
+        <div>
+          <h2>Kết quả nhận dạng</h2>
+          <p id="result-summary" class="muted"></p>
+        </div>
+        <div class="result-actions">
+          <button class="button secondary" id="view-full-text">Xem full text</button>
+          <button class="button" id="download-json">Tải JSON</button>
+        </div>
+      </header>
+      <div id="fields-container" class="fields-grid"></div>
+      <div id="metadata-container" class="metadata"></div>
+    </section>
+
+    <section class="card hidden suggestion" id="suggestion-card">
+      <h3>Gợi ý nâng cấp chế độ OCR</h3>
+      <p>Kết quả FAST có vẻ thiếu dữ liệu. Thử chuyển sang ENHANCED để cải thiện độ chính xác.</p>
+      <button class="button" id="try-enhanced">Chạy lại với ENHANCED</button>
+    </section>
+
+    <section class="card hidden" id="raw-json-card">
+      <header class="result-header">
+        <h3>Dữ liệu JSON</h3>
+        <button class="button secondary" id="toggle-json">Ẩn/hiện</button>
+      </header>
+      <pre id="raw-json"></pre>
+    </section>
+  </main>
+
+  <div class="modal hidden" id="full-text-modal" role="dialog" aria-modal="true">
+    <div class="modal-content">
+      <header>
+        <h3>Full text OCR</h3>
+        <button class="button secondary" id="close-modal">Đóng</button>
+      </header>
+      <pre id="full-text-content"></pre>
+    </div>
+  </div>
+
   <script src="test.js"></script>
 </body>
 </html>

--- a/src/Ocr.Api/wwwroot/test/test.css
+++ b/src/Ocr.Api/wwwroot/test/test.css
@@ -1,26 +1,240 @@
+:root {
+  color-scheme: light;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  --bg: #f5f7fb;
+  --surface: #ffffff;
+  --accent: #2563eb;
+  --accent-soft: rgba(37, 99, 235, 0.12);
+  --text: #0f172a;
+  --muted: #64748b;
+  --border: #dbe3f0;
+  --radius: 12px;
+}
+
 body {
-  font-family: sans-serif;
-  margin: 40px;
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.container {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 40px 24px 80px;
+  box-sizing: border-box;
+}
+
+.hero h1 {
+  margin: 0 0 12px;
+  font-size: clamp(1.8rem, 4vw, 2.4rem);
+}
+
+.hero p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.card {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 28px;
+  margin-top: 28px;
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.1);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.card.hidden {
+  display: none;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+  align-items: end;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.form-field.full {
+  grid-column: 1 / -1;
 }
 
 label {
-  display: block;
-  margin-top: 12px;
+  font-weight: 600;
 }
 
-textarea,
+input,
+select,
+textarea {
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  padding: 12px 14px;
+  font: inherit;
+  background: #fff;
+  transition: border 0.15s ease, box-shadow 0.15s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+
+.actions {
+  grid-column: 1 / -1;
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.button {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  border-radius: 999px;
+  padding: 12px 20px;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.button.secondary {
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--text);
+}
+
+.button:active {
+  transform: translateY(1px);
+  box-shadow: inset 0 2px 4px rgba(15, 23, 42, 0.2);
+}
+
+.result-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 20px;
+  flex-wrap: wrap;
+}
+
+.result-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.muted {
+  color: var(--muted);
+  margin: 4px 0 0;
+}
+
+.fields-grid {
+  display: grid;
+  gap: 16px;
+  margin-top: 24px;
+}
+
+.field-item {
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  padding: 16px;
+  background: rgba(241, 245, 249, 0.5);
+}
+
+.field-item h4 {
+  margin: 0 0 6px;
+  font-size: 1rem;
+}
+
+.field-item p {
+  margin: 0;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.95rem;
+}
+
+.metadata {
+  margin-top: 24px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 12px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.metadata span {
+  padding: 10px 14px;
+  background: rgba(148, 163, 184, 0.1);
+  border-radius: 10px;
+}
+
+.suggestion {
+  border: 1px solid rgba(239, 68, 68, 0.25);
+  background: rgba(254, 226, 226, 0.55);
+}
+
 pre {
-  width: 100%;
-  min-height: 160px;
-  background: #f5f5f5;
-  padding: 12px;
-  border-radius: 4px;
-  border: 1px solid #ddd;
-  box-sizing: border-box;
-  white-space: pre-wrap;
+  margin: 0;
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 16px;
+  border-radius: 10px;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  overflow-x: auto;
 }
 
-button {
-  margin-top: 16px;
-  padding: 10px 16px;
+#raw-json.collapsed {
+  display: none;
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  box-sizing: border-box;
+  z-index: 20;
+}
+
+.modal.hidden {
+  display: none;
+}
+
+.modal-content {
+  background: var(--surface);
+  border-radius: var(--radius);
+  padding: 24px;
+  width: min(720px, 100%);
+  box-shadow: 0 32px 80px rgba(15, 23, 42, 0.4);
+}
+
+.modal-content header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.modal-content pre {
+  max-height: 420px;
+  overflow-y: auto;
+}
+
+@media (max-width: 640px) {
+  .container {
+    padding: 24px 16px 60px;
+  }
+
+  .result-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
 }

--- a/src/Ocr.Api/wwwroot/test/test.js
+++ b/src/Ocr.Api/wwwroot/test/test.js
@@ -1,32 +1,260 @@
 (() => {
   const form = document.getElementById('ocr-form');
-  const resultEl = document.getElementById('result');
+  const submitButton = form?.querySelector('button[type="submit"]');
+  const resetButton = document.getElementById('reset-form');
+  const resultCard = document.getElementById('result-card');
+  const summaryEl = document.getElementById('result-summary');
+  const fieldsContainer = document.getElementById('fields-container');
+  const metadataContainer = document.getElementById('metadata-container');
+  const rawJsonCard = document.getElementById('raw-json-card');
+  const rawJsonEl = document.getElementById('raw-json');
+  const viewFullTextBtn = document.getElementById('view-full-text');
+  const downloadBtn = document.getElementById('download-json');
+  const suggestionCard = document.getElementById('suggestion-card');
+  const tryEnhancedBtn = document.getElementById('try-enhanced');
+  const toggleJsonBtn = document.getElementById('toggle-json');
+  const modal = document.getElementById('full-text-modal');
+  const modalContent = document.getElementById('full-text-content');
+  const closeModalBtn = document.getElementById('close-modal');
+  const modeSelect = document.getElementById('mode-select');
 
-  if (!form || !resultEl) {
+  let currentResult = null;
+
+  if (!form || !submitButton || !summaryEl || !fieldsContainer || !metadataContainer || !rawJsonCard || !rawJsonEl) {
     return;
   }
 
-  form.addEventListener('submit', async (event) => {
+  hideResults();
+
+  form.addEventListener('submit', (event) => {
     event.preventDefault();
-    const data = new FormData(form);
-    resultEl.textContent = 'Đang xử lý...';
+    void submitOcr();
+  });
+
+  form.addEventListener('reset', () => {
+    hideResults();
+  });
+
+  if (tryEnhancedBtn) {
+    tryEnhancedBtn.addEventListener('click', () => {
+      if (!form.file?.files?.length) {
+        showInlineMessage('Vui lòng chọn lại tệp để chạy ENHANCED.');
+        return;
+      }
+      if (modeSelect) {
+        modeSelect.value = 'ENHANCED';
+      }
+      void submitOcr('ENHANCED');
+    });
+  }
+
+  if (viewFullTextBtn && modal && modalContent && closeModalBtn) {
+    viewFullTextBtn.addEventListener('click', () => {
+      if (!currentResult) {
+        return;
+      }
+      modalContent.textContent = getValue(currentResult, 'FullText') || 'Không có nội dung.';
+      modal.classList.remove('hidden');
+    });
+
+    closeModalBtn.addEventListener('click', () => {
+      modal.classList.add('hidden');
+    });
+
+    modal.addEventListener('click', (event) => {
+      if (event.target === modal) {
+        modal.classList.add('hidden');
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        modal.classList.add('hidden');
+      }
+    });
+  }
+
+  if (downloadBtn) {
+    downloadBtn.addEventListener('click', () => {
+      if (!currentResult) {
+        showInlineMessage('Chưa có dữ liệu để tải.');
+        return;
+      }
+      const json = JSON.stringify(currentResult, null, 2);
+      const blob = new Blob([json], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const docType = getValue(currentResult, 'DocumentTypeCode') || 'UNKNOWN';
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `ocr-result-${docType.toString().toLowerCase()}.json`;
+      anchor.click();
+      URL.revokeObjectURL(url);
+    });
+  }
+
+  if (toggleJsonBtn) {
+    toggleJsonBtn.addEventListener('click', () => {
+      const collapsed = rawJsonEl.classList.toggle('collapsed');
+      toggleJsonBtn.textContent = collapsed ? 'Hiện JSON' : 'Ẩn JSON';
+    });
+  }
+
+  if (resetButton) {
+    resetButton.addEventListener('click', hideResults);
+  }
+
+  async function submitOcr(overrideMode) {
+    const formData = new FormData(form);
+    if (overrideMode) {
+      formData.set('mode', overrideMode);
+    }
+
+    resultCard.classList.remove('hidden');
+    summaryEl.textContent = 'Đang xử lý...';
+    fieldsContainer.innerHTML = '';
+    metadataContainer.innerHTML = '';
+    rawJsonCard.classList.add('hidden');
+    suggestionCard?.classList.add('hidden');
+    rawJsonEl.textContent = '';
+    rawJsonEl.classList.remove('collapsed');
+
+    submitButton.disabled = true;
+    const originalText = submitButton.textContent;
+    submitButton.textContent = 'Đang nhận dạng...';
 
     try {
       const response = await fetch('/api/ocr', {
         method: 'POST',
-        body: data
+        body: formData
       });
 
       if (!response.ok) {
         const errorText = await response.text();
-        resultEl.textContent = `Lỗi: ${errorText}`;
-        return;
+        throw new Error(errorText || `HTTP ${response.status}`);
       }
 
       const json = await response.json();
-      resultEl.textContent = JSON.stringify(json, null, 2);
+      renderResult(json);
     } catch (error) {
-      resultEl.textContent = `Lỗi: ${error instanceof Error ? error.message : String(error)}`;
+      summaryEl.textContent = `Lỗi: ${error instanceof Error ? error.message : String(error)}`;
+      fieldsContainer.innerHTML = '';
+      metadataContainer.innerHTML = '';
+      rawJsonCard.classList.add('hidden');
+      suggestionCard?.classList.add('hidden');
+      currentResult = null;
+    } finally {
+      submitButton.disabled = false;
+      submitButton.textContent = originalText;
     }
-  });
+  }
+
+  function renderResult(result) {
+    currentResult = result;
+    const docType = getValue(result, 'DocumentTypeCode') || 'UNKNOWN';
+    const mode = getValue(result, 'Mode') || 'AUTO';
+    const fields = getValue(result, 'Fields') || {};
+    const metadata = getValue(result, 'Metadata');
+    const template = getValue(result, 'TemplateUsed');
+
+    const templateInfo = template ? ` · Template: ${getValue(template, 'Version') || getValue(template, 'version') || 'N/A'}` : '';
+    summaryEl.textContent = `DocType: ${docType} · Engine: ${mode}${templateInfo}`;
+
+    const entries = Object.entries(fields);
+    if (entries.length === 0) {
+      fieldsContainer.innerHTML = '<p class="muted">Chưa trích xuất được trường nào.</p>';
+    } else {
+      fieldsContainer.innerHTML = '';
+      entries.forEach(([key, value]) => {
+        const item = document.createElement('div');
+        item.className = 'field-item';
+        item.innerHTML = `<h4>${escapeHtml(key)}</h4><p>${escapeHtml(String(value))}</p>`;
+        fieldsContainer.append(item);
+      });
+    }
+
+    if (metadata && typeof metadata === 'object' && Object.keys(metadata).length > 0) {
+      metadataContainer.innerHTML = '';
+      Object.entries(metadata).forEach(([key, value]) => {
+        const span = document.createElement('span');
+        span.textContent = `${key}: ${formatMetadataValue(value)}`;
+        metadataContainer.append(span);
+      });
+    } else {
+      metadataContainer.innerHTML = '';
+    }
+
+    rawJsonEl.textContent = JSON.stringify(result, null, 2);
+    rawJsonEl.classList.remove('collapsed');
+    rawJsonCard.classList.remove('hidden');
+    toggleJsonBtn.textContent = 'Ẩn JSON';
+
+    if (shouldSuggestEnhanced(result)) {
+      suggestionCard?.classList.remove('hidden');
+    } else {
+      suggestionCard?.classList.add('hidden');
+    }
+  }
+
+  function hideResults() {
+    currentResult = null;
+    resultCard.classList.add('hidden');
+    rawJsonCard.classList.add('hidden');
+    suggestionCard?.classList.add('hidden');
+    summaryEl.textContent = '';
+    fieldsContainer.innerHTML = '';
+    metadataContainer.innerHTML = '';
+    rawJsonEl.textContent = '';
+    rawJsonEl.classList.remove('collapsed');
+    modal?.classList.add('hidden');
+  }
+
+  function shouldSuggestEnhanced(result) {
+    const mode = (getValue(result, 'Mode') || '').toString().toUpperCase();
+    if (!mode.includes('FAST')) {
+      return false;
+    }
+
+    const fields = getValue(result, 'Fields') || {};
+    const fieldCount = Object.keys(fields).length;
+    const fullText = (getValue(result, 'FullText') || '').toString();
+    return fieldCount === 0 || fullText.length < 40;
+  }
+
+  function showInlineMessage(message) {
+    summaryEl.textContent = message;
+    resultCard.classList.remove('hidden');
+  }
+
+  function getValue(obj, key) {
+    if (!obj) {
+      return undefined;
+    }
+    if (Object.prototype.hasOwnProperty.call(obj, key)) {
+      return obj[key];
+    }
+    const camel = key.charAt(0).toLowerCase() + key.slice(1);
+    if (Object.prototype.hasOwnProperty.call(obj, camel)) {
+      return obj[camel];
+    }
+    return undefined;
+  }
+
+  function escapeHtml(value) {
+    return value
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function formatMetadataValue(value) {
+    if (value === null || value === undefined) {
+      return '—';
+    }
+    if (typeof value === 'object') {
+      return JSON.stringify(value);
+    }
+    return String(value);
+  }
 })();


### PR DESCRIPTION
## Summary
- document core admin and end-user UI requirements for the mock implementation
- add in-memory mock store plus `/api/mock/**` endpoints to simulate admin workflows
- build a modular admin single-page UI for doc types, samples, templates, samplers, and training flows
- refresh the `/test` client with richer result presentation, JSON download, full-text modal, and enhanced mode suggestion

## Testing
- `dotnet build` *(fails: command not found in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d0fd760ea083288d3eda0dce802a15