### PR TITLE
Add OCR service with Tesseract and Paddle pipelines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.pyc
+.env
+storage/
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.10-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    tesseract-ocr \
+    poppler-utils \
+    libreoffice \
+    fonts-dejavu-core \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+COPY README.md ./README.md
+
+EXPOSE 8000
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,79 @@
-"# OCR" 
+# OCR Service
+
+Dịch vụ OCR mẫu được xây dựng cho hệ thống quản lý khoản vay. Mục tiêu là cung cấp API OCR mạnh mẽ có thể xử lý nhiều định dạng tài liệu (Word, PDF văn bản, PDF scan, ảnh) với hai động cơ lõi: Tesseract và PaddleOCR. Toàn bộ lịch sử các lần chạy OCR được lưu trữ trong SQLite cùng với các tệp trung gian để phục vụ việc kiểm tra, tái tạo.
+
+## Tính năng chính
+
+- **API FastAPI**: Endpoint REST để tải tài liệu và lựa chọn động cơ OCR (`tesseract` hoặc `paddle`).
+- **Tiền xử lý ảnh**: Pipeline tự động gồm chuyển xám, cân bằng tương phản, lọc nhiễu, nhị phân hóa nhằm nâng cao độ chính xác OCR.
+- **Hỗ trợ đa định dạng**: Ảnh (`png`, `jpg`, `jpeg`, `tiff`, `bmp`), PDF, Word (`doc`, `docx`). Word được chuyển sang PDF bằng LibreOffice để trích xuất ảnh trang.
+- **Quản lý lịch sử**: Lưu vào SQLite thông tin tệp gốc, tệp chuyển đổi, ảnh gốc, ảnh tiền xử lý, văn bản OCR kèm độ tin cậy.
+- **Lưu trữ tệp**: Toàn bộ tệp gốc, trang PDF, ảnh tiền xử lý được lưu trong thư mục `storage/` theo từng lần chạy.
+- **Docker hóa**: Dockerfile cài đặt đầy đủ phụ thuộc (Tesseract, LibreOffice, Poppler, PaddleOCR) để triển khai nhất quán.
+
+## Cấu trúc thư mục
+
+```
+app/
+  config.py          # Cấu hình ứng dụng
+  database.py        # Khởi tạo SQLite + SQLAlchemy session
+  main.py            # FastAPI app và endpoints
+  models.py          # Mô hình ORM
+  schemas.py         # Schema Pydantic cho API
+  services/
+    file_processing.py  # Lưu file, chuyển đổi PDF/Word → ảnh
+    preprocess.py       # Pipeline tiền xử lý ảnh
+    ocr_base.py         # Định nghĩa giao diện OCR
+    tesseract_engine.py # Triển khai động cơ Tesseract
+    paddle_engine.py    # Triển khai động cơ PaddleOCR
+    ocr_service.py      # Điều phối toàn bộ quy trình OCR
+requirements.txt    # Các phụ thuộc Python
+Dockerfile          # Docker hóa dịch vụ
+```
+
+## Chạy dịch vụ cục bộ
+
+### Yêu cầu hệ thống
+
+- Docker và Docker Compose
+
+### Các bước chạy
+
+```bash
+docker build -t ocr-service .
+docker run -p 8000:8000 -v $(pwd)/storage:/app/storage ocr-service
+```
+
+Sau khi container chạy, API sẵn sàng tại `http://localhost:8000`. Truy cập `http://localhost:8000/docs` để thử nghiệm Swagger UI.
+
+### Gọi thử API bằng `curl`
+
+```bash
+curl -X POST "http://localhost:8000/api/v1/ocr?engine=tesseract" \
+  -H "accept: application/json" \
+  -H "Content-Type: multipart/form-data" \
+  -F "file=@/path/to/document.pdf"
+```
+
+## Lịch sử OCR
+
+Các bảng chính trong SQLite (`storage/ocr.db`):
+
+- `ocr_runs`: thông tin mỗi lần chạy (engine, đường dẫn tệp gốc, tệp chuyển đổi, văn bản tổng hợp tốt nhất, độ tin cậy).
+- `ocr_images`: toàn bộ ảnh gốc và ảnh tiền xử lý, kèm nhãn và thứ tự.
+- `ocr_text_results`: kết quả OCR cho từng biến thể ảnh, kèm confidence.
+
+Có thể kiểm tra lịch sử qua API:
+
+- `GET /api/v1/ocr`: Danh sách tất cả các lần chạy (mới nhất trước).
+- `GET /api/v1/ocr/{id}`: Chi tiết một lần chạy.
+
+## Ghi chú triển khai
+
+- Pipeline tiền xử lý được thiết kế để cải thiện khả năng đọc của Tesseract/PaddleOCR, có thể mở rộng thêm các bước khác (ví dụ deskew, loại bỏ nhiễu nâng cao).
+- Nếu xử lý khối lượng lớn, cân nhắc thêm hàng đợi (Celery/RQ) và lưu trữ ngoài (S3, MinIO) cho các tệp trung gian.
+- PaddleOCR yêu cầu nhiều tài nguyên hơn so với Tesseract; trong Dockerfile đã cấu hình để sử dụng CPU.
+
+## Giấy phép
+
+Dự án nghiên cứu mẫu – tùy chỉnh theo nhu cầu thực tế.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""OCR service package."""

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from pathlib import Path
+from pydantic import BaseSettings, Field
+
+
+class Settings(BaseSettings):
+    """Application configuration."""
+
+    data_dir: Path = Field(default=Path("storage"), env="OCR_DATA_DIR")
+    database_url: str = Field(default="sqlite:///storage/ocr.db", env="OCR_DATABASE_URL")
+    pdf_dpi: int = Field(default=300, env="OCR_PDF_DPI")
+    tess_lang: str = Field(default="eng", env="OCR_TESS_LANG")
+    paddle_lang: str = Field(default="en", env="OCR_PADDLE_LANG")
+
+    class Config:
+        env_file = ".env"
+        case_sensitive = False
+
+
+settings = Settings()
+settings.data_dir.mkdir(parents=True, exist_ok=True)

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
+
+from .config import settings
+
+
+engine = create_engine(
+    settings.database_url,
+    connect_args={"check_same_thread": False} if settings.database_url.startswith("sqlite") else {},
+)
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+Base = declarative_base()
+
+
+@contextmanager
+def session_scope() -> Iterator[Session]:
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from fastapi import FastAPI, File, HTTPException, UploadFile
+
+from sqlalchemy.orm import selectinload
+
+from .database import Base, engine, session_scope
+from .models import OCRRun
+from .schemas import OCRResponseSchema, OCRRunSchema
+from .services.ocr_service import OCRService
+
+app = FastAPI(title="OCR Service", version="1.0.0")
+
+Base.metadata.create_all(bind=engine)
+ocr_service = OCRService()
+
+
+@app.post("/api/v1/ocr", response_model=OCRResponseSchema)
+async def run_ocr(engine: str = "tesseract", file: UploadFile = File(...)):
+    try:
+        run = ocr_service.process(file=file, engine_name=engine)
+    except Exception as exc:  # pragma: no cover - guard rails
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"run": run}
+
+
+@app.get("/api/v1/ocr", response_model=list[OCRRunSchema])
+async def list_runs():
+    with session_scope() as session:
+        runs = (
+            session.query(OCRRun)
+            .options(selectinload(OCRRun.images), selectinload(OCRRun.text_results))
+            .order_by(OCRRun.created_at.desc())
+            .all()
+        )
+        for run in runs:
+            for image in run.images:
+                session.expunge(image)
+            for result in run.text_results:
+                session.expunge(result)
+            session.expunge(run)
+    return runs
+
+
+@app.get("/api/v1/ocr/{run_id}", response_model=OCRRunSchema)
+async def get_run(run_id: int):
+    with session_scope() as session:
+        run = session.get(
+            OCRRun,
+            run_id,
+            options=(selectinload(OCRRun.images), selectinload(OCRRun.text_results)),
+        )
+        if not run:
+            raise HTTPException(status_code=404, detail="Run not found")
+        for image in run.images:
+            session.expunge(image)
+        for result in run.text_results:
+            session.expunge(result)
+        session.expunge(run)
+    return run

--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import List, Optional
+
+from sqlalchemy import DateTime, Float, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from .database import Base
+
+
+class OCRRun(Base):
+    __tablename__ = "ocr_runs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    engine: Mapped[str] = mapped_column(String(50))
+    original_file_path: Mapped[str] = mapped_column(String)
+    converted_file_path: Mapped[Optional[str]] = mapped_column(String, nullable=True)
+    summary_text: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    best_confidence: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+
+    images: Mapped[List["OCRImage"]] = relationship("OCRImage", back_populates="run", cascade="all, delete-orphan")
+    text_results: Mapped[List["OCRTextResult"]] = relationship("OCRTextResult", back_populates="run", cascade="all, delete-orphan")
+
+
+class OCRImage(Base):
+    __tablename__ = "ocr_images"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    run_id: Mapped[int] = mapped_column(ForeignKey("ocr_runs.id", ondelete="CASCADE"))
+    path: Mapped[str] = mapped_column(String)
+    kind: Mapped[str] = mapped_column(String(20))  # source or preprocessed
+    label: Mapped[str] = mapped_column(String(100))
+    sequence: Mapped[int] = mapped_column(Integer, default=0)
+
+    run: Mapped[OCRRun] = relationship("OCRRun", back_populates="images")
+    text_results: Mapped[List["OCRTextResult"]] = relationship("OCRTextResult", back_populates="image")
+
+
+class OCRTextResult(Base):
+    __tablename__ = "ocr_text_results"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    run_id: Mapped[int] = mapped_column(ForeignKey("ocr_runs.id", ondelete="CASCADE"))
+    image_id: Mapped[Optional[int]] = mapped_column(ForeignKey("ocr_images.id", ondelete="SET NULL"))
+    variant_label: Mapped[str] = mapped_column(String(100))
+    text: Mapped[str] = mapped_column(Text)
+    confidence: Mapped[Optional[float]] = mapped_column(Float, nullable=True)
+
+    run: Mapped[OCRRun] = relationship("OCRRun", back_populates="text_results")
+    image: Mapped[Optional[OCRImage]] = relationship("OCRImage", back_populates="text_results")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class OCRImageSchema(BaseModel):
+    id: int
+    path: Path
+    kind: str
+    label: str
+    sequence: int
+
+    class Config:
+        orm_mode = True
+
+
+class OCRTextResultSchema(BaseModel):
+    id: int
+    variant_label: str
+    text: str
+    confidence: Optional[float]
+    image_id: Optional[int]
+
+    class Config:
+        orm_mode = True
+
+
+class OCRRunSchema(BaseModel):
+    id: int
+    created_at: datetime
+    engine: str
+    original_file_path: Path
+    converted_file_path: Optional[Path]
+    summary_text: Optional[str]
+    best_confidence: Optional[float]
+    images: List[OCRImageSchema]
+    text_results: List[OCRTextResultSchema]
+
+    class Config:
+        orm_mode = True
+
+
+class OCRRequestSchema(BaseModel):
+    engine: str = "tesseract"
+
+
+class OCRResponseSchema(BaseModel):
+    run: OCRRunSchema

--- a/app/services/file_processing.py
+++ b/app/services/file_processing.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import List
+
+from pdf2image import convert_from_path
+from PIL import Image
+
+from ..config import settings
+
+SUPPORTED_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".tiff", ".bmp"}
+SUPPORTED_DOCUMENT_EXTENSIONS = {".pdf", ".doc", ".docx"}
+
+
+def save_upload_file(uploaded_file, destination: Path) -> Path:
+    uploaded_file.file.seek(0)
+    with destination.open("wb") as buffer:
+        shutil.copyfileobj(uploaded_file.file, buffer)
+    uploaded_file.file.close()
+    return destination
+
+
+def ensure_pdf(path: Path, output_dir: Path) -> Path:
+    suffix = path.suffix.lower()
+    if suffix == ".pdf":
+        return path
+    if suffix in {".doc", ".docx"}:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        pdf_path = output_dir / f"{path.stem}.pdf"
+        command = [
+            "libreoffice",
+            "--headless",
+            "--convert-to",
+            "pdf",
+            str(path),
+            "--outdir",
+            str(output_dir),
+        ]
+        subprocess.run(command, check=True)
+        return pdf_path
+    raise ValueError(f"Unsupported document format: {path.suffix}")
+
+
+def pdf_to_images(pdf_path: Path, output_dir: Path) -> List[Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    images = convert_from_path(str(pdf_path), dpi=settings.pdf_dpi)
+    paths: List[Path] = []
+    for index, image in enumerate(images, start=1):
+        path = output_dir / f"page_{index:03d}.png"
+        image.save(path, format="PNG")
+        paths.append(path)
+    return paths
+
+
+def load_image(path: Path) -> Image.Image:
+    with Image.open(path) as img:
+        return img.convert("RGB")

--- a/app/services/ocr_base.py
+++ b/app/services/ocr_base.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from PIL import Image
+
+
+@dataclass
+class OcrOutput:
+    text: str
+    confidence: float | None
+
+
+class OCREngine(Protocol):
+    name: str
+
+    def run(self, image: Image.Image) -> OcrOutput:
+        ...

--- a/app/services/ocr_service.py
+++ b/app/services/ocr_service.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from typing import Dict, List, Tuple
+
+from fastapi import UploadFile
+from sqlalchemy.orm import selectinload
+from PIL import Image
+
+from ..config import settings
+from ..database import session_scope
+from ..models import OCRImage, OCRRun, OCRTextResult
+from .file_processing import (
+    SUPPORTED_DOCUMENT_EXTENSIONS,
+    SUPPORTED_IMAGE_EXTENSIONS,
+    ensure_pdf,
+    load_image,
+    pdf_to_images,
+    save_upload_file,
+)
+from .ocr_base import OCREngine
+from .paddle_engine import PaddleOCREngine
+from .preprocess import ImagePreprocessor
+from .tesseract_engine import TesseractEngine
+
+class OCRService:
+    def __init__(self) -> None:
+        self.preprocessor = ImagePreprocessor()
+        self.engines: Dict[str, OCREngine] = {
+            "tesseract": TesseractEngine(),
+            "paddle": PaddleOCREngine(),
+        }
+
+    def get_engine(self, name: str) -> OCREngine:
+        if name not in self.engines:
+            raise ValueError(f"Unsupported OCR engine: {name}")
+        return self.engines[name]
+
+    def process(self, file: UploadFile, engine_name: str) -> OCRRun:
+        engine = self.get_engine(engine_name)
+        run_dir = settings.data_dir / uuid.uuid4().hex
+        original_dir = run_dir / "original"
+        original_dir.mkdir(parents=True, exist_ok=True)
+        original_path = original_dir / file.filename
+        save_upload_file(file, original_path)
+
+        run = OCRRun(engine=engine.name, original_file_path=str(original_path))
+
+        images: List[Tuple[Path, Image.Image]] = []
+        converted_pdf_path: Path | None = None
+
+        suffix = original_path.suffix.lower()
+        if suffix in SUPPORTED_IMAGE_EXTENSIONS:
+            image = load_image(original_path)
+            images.append((original_path, image))
+        elif suffix in SUPPORTED_DOCUMENT_EXTENSIONS:
+            converted_dir = run_dir / "converted"
+            converted_dir.mkdir(parents=True, exist_ok=True)
+            if suffix == ".pdf":
+                converted_pdf_path = original_path
+            else:
+                converted_pdf_path = ensure_pdf(original_path, converted_dir)
+            run.converted_file_path = str(converted_pdf_path)
+            images_paths = pdf_to_images(converted_pdf_path, run_dir / "pages")
+            for path in images_paths:
+                images.append((path, load_image(path)))
+        else:
+            raise ValueError(f"Unsupported file type: {suffix}")
+
+        with session_scope() as session:
+            session.add(run)
+            session.flush()
+
+            for index, (image_path, image) in enumerate(images, start=1):
+                db_image = OCRImage(
+                    run_id=run.id,
+                    path=str(image_path),
+                    kind="source",
+                    label=f"page_{index}",
+                    sequence=index,
+                )
+                session.add(db_image)
+                session.flush()
+
+                variants = self.preprocessor.generate(image)
+                for order, (label, variant_image) in enumerate(variants):
+                    variant_path = run_dir / "preprocessed" / f"{db_image.label}_{label}.png"
+                    variant_path.parent.mkdir(parents=True, exist_ok=True)
+                    variant_image.save(variant_path, format="PNG")
+                    db_variant_image = OCRImage(
+                        run_id=run.id,
+                        path=str(variant_path),
+                        kind="preprocessed",
+                        label=f"{db_image.label}_{label}",
+                        sequence=order,
+                    )
+                    session.add(db_variant_image)
+                    session.flush()
+
+                    result = engine.run(variant_image)
+                    text_result = OCRTextResult(
+                        run_id=run.id,
+                        image_id=db_variant_image.id,
+                        variant_label=db_variant_image.label,
+                        text=result.text,
+                        confidence=result.confidence,
+                    )
+                    session.add(text_result)
+
+            session.flush()
+            best = self._select_best_result(run)
+            if best:
+                run.summary_text = best.text
+                run.best_confidence = best.confidence
+            session.add(run)
+            session.commit()
+            refreshed_run = (
+                session.query(OCRRun)
+                .options(selectinload(OCRRun.images), selectinload(OCRRun.text_results))
+                .get(run.id)
+            )
+            if refreshed_run is not None:
+                for image in refreshed_run.images:
+                    session.expunge(image)
+                for result in refreshed_run.text_results:
+                    session.expunge(result)
+                session.expunge(refreshed_run)
+        return refreshed_run
+
+    def _select_best_result(self, run: OCRRun) -> OCRTextResult | None:
+        if not run.text_results:
+            return None
+        sorted_results = sorted(
+            run.text_results,
+            key=lambda r: (r.confidence if r.confidence is not None else 0.0, len(r.text)),
+            reverse=True,
+        )
+        return sorted_results[0]

--- a/app/services/paddle_engine.py
+++ b/app/services/paddle_engine.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import statistics
+from typing import Optional
+
+import numpy as np
+from paddleocr import PaddleOCR
+from PIL import Image
+
+from ..config import settings
+from .ocr_base import OCREngine, OcrOutput
+
+
+class PaddleOCREngine:
+    name = "paddle"
+
+    def __init__(self, lang: Optional[str] = None) -> None:
+        self.lang = lang or settings.paddle_lang
+        self._ocr = PaddleOCR(use_angle_cls=True, lang=self.lang, show_log=False)
+
+    def run(self, image: Image.Image) -> OcrOutput:
+        np_image = np.array(image.convert("RGB"))
+        results = self._ocr.ocr(np_image, cls=True)
+        texts = []
+        confidences = []
+        for res in results:
+            for line in res:
+                text, confidence = line[1][0], float(line[1][1])
+                texts.append(text)
+                confidences.append(confidence)
+        aggregated_text = "\n".join(texts)
+        confidence = statistics.mean(confidences) if confidences else None
+        return OcrOutput(text=aggregated_text.strip(), confidence=confidence)

--- a/app/services/preprocess.py
+++ b/app/services/preprocess.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import List, Tuple
+
+from PIL import Image, ImageFilter, ImageOps
+
+
+class ImagePreprocessor:
+    """Apply a simple but effective preprocessing pipeline."""
+
+    def __init__(self) -> None:
+        self.steps = (
+            ("original", self._identity),
+            ("grayscale", self._to_grayscale),
+            ("contrast", self._enhance_contrast),
+            ("median_filter", self._median_filter),
+            ("threshold", self._threshold),
+        )
+
+    def generate(self, image: Image.Image) -> List[Tuple[str, Image.Image]]:
+        outputs: List[Tuple[str, Image.Image]] = []
+        current = image
+        for label, fn in self.steps:
+            current = fn(current if label != "original" else image)
+            outputs.append((label, current))
+        return outputs
+
+    @staticmethod
+    def _identity(image: Image.Image) -> Image.Image:
+        return image.copy()
+
+    @staticmethod
+    def _to_grayscale(image: Image.Image) -> Image.Image:
+        return ImageOps.grayscale(image)
+
+    @staticmethod
+    def _enhance_contrast(image: Image.Image) -> Image.Image:
+        return ImageOps.autocontrast(image)
+
+    @staticmethod
+    def _median_filter(image: Image.Image) -> Image.Image:
+        return image.filter(ImageFilter.MedianFilter(size=3))
+
+    @staticmethod
+    def _threshold(image: Image.Image) -> Image.Image:
+        if image.mode != "L":
+            image = ImageOps.grayscale(image)
+        return image.point(lambda p: 255 if p > 160 else 0, mode="1").convert("L")

--- a/app/services/tesseract_engine.py
+++ b/app/services/tesseract_engine.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import statistics
+from typing import Optional
+
+import pytesseract
+from pytesseract import Output
+from PIL import Image
+
+from ..config import settings
+from .ocr_base import OCREngine, OcrOutput
+
+
+class TesseractEngine:
+    name = "tesseract"
+
+    def __init__(self, lang: Optional[str] = None) -> None:
+        self.lang = lang or settings.tess_lang
+
+    def run(self, image: Image.Image) -> OcrOutput:
+        text = pytesseract.image_to_string(image, lang=self.lang)
+        data = pytesseract.image_to_data(image, lang=self.lang, output_type=Output.DICT)
+        confidences = [float(conf) for conf in data.get("conf", []) if conf not in {"-1", "-1.0"}]
+        confidence = statistics.mean(confidences) if confidences else None
+        return OcrOutput(text=text.strip(), confidence=confidence)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,12 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+sqlalchemy==2.0.29
+pydantic==1.10.14
+python-multipart==0.0.9
+pillow==10.3.0
+pdf2image==1.17.0
+pytesseract==0.3.10
+paddlepaddle==2.5.2
+paddleocr==2.7.0.3
+python-docx==1.1.0
+numpy==1.26.4


### PR DESCRIPTION
## Summary
- introduce a FastAPI-based OCR service that stores run history and intermediate artifacts in SQLite
- add modular processing pipeline with preprocessing steps, Tesseract and PaddleOCR engines, and converters for PDF/Word/image inputs
- provide Docker image, configuration, and documentation for building and running the OCR service

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68dba1a20094832893021092f6d5530e