### PR TITLE
Bump PaddlePaddle to 2.6.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ python-multipart==0.0.9
 pillow==10.3.0
 pdf2image==1.17.0
 pytesseract==0.3.10
-paddlepaddle==2.5.2
+paddlepaddle==2.6.2
 paddleocr==2.7.0.3
 python-docx==1.1.0
 numpy==1.26.4


### PR DESCRIPTION
## Summary
- update the PaddlePaddle dependency to version 2.6.2 to track the latest compatible CPU wheel release

## Testing
- pip install -r requirements.txt *(fails: cancelled during lengthy PyMuPDF build after confirming PaddlePaddle resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68dba8c3b80083289f5078441b839782