### PR TITLE
Install missing OpenCV runtime libraries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     poppler-utils \
     libreoffice \
     fonts-dejavu-core \
+    libgl1 \
+    libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app


### PR DESCRIPTION
## Summary
- add libGL and GLib runtime dependencies required by OpenCV to the image build

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbb5422b288328a73d6a0bf164f95b