### PR TITLE
Add web interface for managing OCR runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ docker run -p 8000:8000 -v $(pwd)/storage:/app/storage ocr-service
 
 Sau khi container chạy, API sẵn sàng tại `http://localhost:8000`. Truy cập `http://localhost:8000/docs` để thử nghiệm Swagger UI.
 
+### Truy cập giao diện web
+
+Sau khi container chạy, truy cập `http://localhost:8000/` để mở giao diện quản trị. Tại đây có thể tải tài liệu,
+theo dõi lịch sử các phiên OCR và xem chi tiết từng trang ảnh/kết quả văn bản.
+
 ### Gọi thử API bằng `curl`
 
 ```bash

--- a/app/main.py
+++ b/app/main.py
@@ -1,18 +1,59 @@
 from __future__ import annotations
 
-from fastapi import FastAPI, File, HTTPException, UploadFile
+from datetime import datetime
+from pathlib import Path
+
+from fastapi import FastAPI, File, Form, HTTPException, UploadFile, Request
+from fastapi.responses import FileResponse, HTMLResponse, RedirectResponse
+from fastapi.templating import Jinja2Templates
 
 from sqlalchemy.orm import selectinload
 
 from .database import Base, engine, session_scope
-from .models import OCRRun
+from .models import OCRImage, OCRRun
 from .schemas import OCRResponseSchema, OCRRunSchema
 from .services.ocr_service import OCRService
 
 app = FastAPI(title="OCR Service", version="1.0.0")
 
+templates = Jinja2Templates(directory=str(Path(__file__).resolve().parent / "templates"))
+
 Base.metadata.create_all(bind=engine)
 ocr_service = OCRService()
+
+
+def _detach_run(session, run: OCRRun) -> OCRRun:
+    """Detach ORM objects so they can be safely returned/used after the session."""
+
+    for image in run.images:
+        session.expunge(image)
+    for result in run.text_results:
+        session.expunge(result)
+    session.expunge(run)
+    return run
+
+
+def _load_runs() -> list[OCRRun]:
+    with session_scope() as session:
+        runs = (
+            session.query(OCRRun)
+            .options(selectinload(OCRRun.images), selectinload(OCRRun.text_results))
+            .order_by(OCRRun.created_at.desc())
+            .all()
+        )
+        return [_detach_run(session, run) for run in runs]
+
+
+def _load_run(run_id: int) -> OCRRun | None:
+    with session_scope() as session:
+        run = session.get(
+            OCRRun,
+            run_id,
+            options=(selectinload(OCRRun.images), selectinload(OCRRun.text_results)),
+        )
+        if not run:
+            return None
+        return _detach_run(session, run)
 
 
 @app.post("/api/v1/ocr", response_model=OCRResponseSchema)
@@ -24,37 +65,111 @@ async def run_ocr(engine: str = "tesseract", file: UploadFile = File(...)):
     return {"run": run}
 
 
+@app.get("/api/v1/ocr/engines", response_model=list[str])
+async def list_engines():
+    return list(ocr_service.engines.keys())
+
+
 @app.get("/api/v1/ocr", response_model=list[OCRRunSchema])
 async def list_runs():
-    with session_scope() as session:
-        runs = (
-            session.query(OCRRun)
-            .options(selectinload(OCRRun.images), selectinload(OCRRun.text_results))
-            .order_by(OCRRun.created_at.desc())
-            .all()
-        )
-        for run in runs:
-            for image in run.images:
-                session.expunge(image)
-            for result in run.text_results:
-                session.expunge(result)
-            session.expunge(run)
-    return runs
+    return _load_runs()
 
 
 @app.get("/api/v1/ocr/{run_id}", response_model=OCRRunSchema)
 async def get_run(run_id: int):
-    with session_scope() as session:
-        run = session.get(
-            OCRRun,
-            run_id,
-            options=(selectinload(OCRRun.images), selectinload(OCRRun.text_results)),
-        )
-        if not run:
-            raise HTTPException(status_code=404, detail="Run not found")
-        for image in run.images:
-            session.expunge(image)
-        for result in run.text_results:
-            session.expunge(result)
-        session.expunge(run)
+    run = _load_run(run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail="Run not found")
     return run
+
+
+@app.get("/", response_class=HTMLResponse)
+async def home(request: Request):
+    runs = _load_runs()
+    engines = list(ocr_service.engines.keys())
+    selected_engine = "tesseract" if "tesseract" in ocr_service.engines else (engines[0] if engines else "")
+    return templates.TemplateResponse(
+        "index.html",
+        {
+            "request": request,
+            "runs": runs,
+            "engines": engines,
+            "selected_engine": selected_engine,
+            "error": None,
+            "now": datetime.utcnow(),
+        },
+    )
+
+
+@app.post("/upload", response_class=HTMLResponse)
+async def upload_document(
+    request: Request,
+    engine: str = Form("tesseract"),
+    file: UploadFile = File(...),
+):
+    engines = list(ocr_service.engines.keys())
+    try:
+        run = ocr_service.process(file=file, engine_name=engine)
+    except Exception as exc:  # pragma: no cover - guard rails
+        runs = _load_runs()
+        return templates.TemplateResponse(
+            "index.html",
+            {
+                "request": request,
+                "runs": runs,
+                "engines": engines,
+                "selected_engine": engine,
+                "error": str(exc),
+                "now": datetime.utcnow(),
+            },
+            status_code=400,
+        )
+    return RedirectResponse(url=f"/runs/{run.id}", status_code=303)
+
+
+@app.get("/runs/{run_id}", response_class=HTMLResponse)
+async def run_detail(request: Request, run_id: int):
+    run = _load_run(run_id)
+    if not run:
+        raise HTTPException(status_code=404, detail="Run not found")
+
+    source_images = sorted((img for img in run.images if img.kind == "source"), key=lambda img: img.sequence)
+    preprocessed_images = sorted(
+        (img for img in run.images if img.kind == "preprocessed"),
+        key=lambda img: (img.label, img.sequence),
+    )
+    results = sorted(
+        run.text_results,
+        key=lambda r: (r.confidence if r.confidence is not None else 0.0, len(r.text)),
+        reverse=True,
+    )
+
+    return templates.TemplateResponse(
+        "run_detail.html",
+        {
+            "request": request,
+            "run": run,
+            "source_images": list(source_images),
+            "preprocessed_images": list(preprocessed_images),
+            "results": results,
+            "now": datetime.utcnow(),
+        },
+    )
+
+
+@app.get("/runs/{run_id}/images/{image_id}")
+async def get_run_image(run_id: int, image_id: int):
+    with session_scope() as session:
+        image = (
+            session.query(OCRImage)
+            .filter(OCRImage.run_id == run_id, OCRImage.id == image_id)
+            .one_or_none()
+        )
+        if image is None:
+            raise HTTPException(status_code=404, detail="Image not found")
+        session.expunge(image)
+
+    image_path = Path(image.path)
+    if not image_path.exists():
+        raise HTTPException(status_code=404, detail="Image file missing on server")
+    return FileResponse(image_path)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,145 @@
+<!DOCTYPE html>
+<html lang="vi">
+  <head>
+    <meta charset="utf-8" />
+    <title>{% block title %}OCR Service{% endblock %}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Segoe UI", Helvetica, Arial, sans-serif;
+      }
+      body {
+        margin: 0;
+        padding: 0;
+        background-color: #f6f8fa;
+        color: #24292f;
+      }
+      header {
+        background-color: #0d6efd;
+        color: #fff;
+        padding: 1.5rem;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+      }
+      header h1 {
+        margin: 0;
+        font-size: 1.75rem;
+      }
+      main {
+        max-width: 1024px;
+        margin: 0 auto;
+        padding: 2rem 1.5rem 3rem;
+      }
+      a {
+        color: #0d6efd;
+        text-decoration: none;
+      }
+      a:hover {
+        text-decoration: underline;
+      }
+      .card {
+        background-color: #fff;
+        border-radius: 12px;
+        padding: 1.5rem;
+        margin-bottom: 1.5rem;
+        box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+      }
+      .card h2,
+      .card h3 {
+        margin-top: 0;
+      }
+      .btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        background-color: #0d6efd;
+        color: #fff;
+        border-radius: 999px;
+        padding: 0.5rem 1.25rem;
+        border: none;
+        cursor: pointer;
+        font-weight: 600;
+      }
+      .btn.secondary {
+        background-color: #fff;
+        color: #0d6efd;
+        border: 1px solid #0d6efd;
+      }
+      .btn:hover {
+        filter: brightness(0.95);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      table thead {
+        background-color: #f1f5f9;
+      }
+      table th,
+      table td {
+        padding: 0.75rem 0.5rem;
+        border-bottom: 1px solid #e2e8f0;
+        text-align: left;
+      }
+      .grid {
+        display: grid;
+        gap: 1rem;
+      }
+      .grid.two {
+        grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      }
+      .tag {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        background-color: #e0f2fe;
+        color: #0c4a6e;
+        border-radius: 999px;
+        padding: 0.25rem 0.75rem;
+        font-size: 0.85rem;
+        font-weight: 600;
+      }
+      .error {
+        background-color: #fee2e2;
+        color: #b91c1c;
+        padding: 0.75rem 1rem;
+        border-radius: 8px;
+        margin-bottom: 1rem;
+      }
+      pre {
+        white-space: pre-wrap;
+        word-break: break-word;
+        background-color: #f8fafc;
+        padding: 1rem;
+        border-radius: 8px;
+        border: 1px solid #e2e8f0;
+      }
+      img.preview {
+        max-width: 100%;
+        border-radius: 8px;
+        border: 1px solid #e2e8f0;
+      }
+      footer {
+        text-align: center;
+        padding: 2rem 1rem 3rem;
+        color: #64748b;
+        font-size: 0.9rem;
+      }
+    </style>
+    {% block head %}{% endblock %}
+  </head>
+  <body>
+    <header>
+      <h1>Hệ thống OCR</h1>
+      <p style="margin: 0.25rem 0 0; font-size: 0.95rem; opacity: 0.85;">
+        Giao diện quản lý và theo dõi các lần chạy OCR
+      </p>
+    </header>
+    <main>
+      {% block content %}{% endblock %}
+    </main>
+    <footer>
+      &copy; {{ now.year }} OCR Service. Triển khai minh hoạ.
+    </footer>
+  </body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,85 @@
+{% extends "base.html" %}
+{% block title %}OCR Service - Tổng quan{% endblock %}
+{% block content %}
+<div class="card">
+  <h2>Tải tài liệu mới</h2>
+  <p>Chọn động cơ OCR và tải lên tài liệu (ảnh, PDF, Word) để bắt đầu xử lý.</p>
+  {% if error %}
+  <div class="error">{{ error }}</div>
+  {% endif %}
+  <form action="/upload" method="post" enctype="multipart/form-data" class="grid two">
+    <label>
+      <span>Chọn động cơ OCR</span>
+      <select name="engine" style="width: 100%; padding: 0.5rem; border-radius: 8px; border: 1px solid #cbd5e1; margin-top: 0.5rem;">
+        {% for engine in engines %}
+        <option value="{{ engine }}" {% if engine == selected_engine %}selected{% endif %}>{{ engine|capitalize }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <label>
+      <span>Tài liệu đầu vào</span>
+      <input
+        type="file"
+        name="file"
+        accept=".png,.jpg,.jpeg,.tiff,.bmp,.pdf,.doc,.docx"
+        required
+        style="width: 100%; padding: 0.5rem; border-radius: 8px; border: 1px solid #cbd5e1; margin-top: 0.5rem;"
+      />
+    </label>
+    <div>
+      <button class="btn" type="submit">Thực hiện OCR</button>
+      <p style="margin-top: 0.75rem; font-size: 0.9rem; color: #64748b;">
+        Sau khi hoàn tất sẽ chuyển tới trang chi tiết kết quả.
+      </p>
+    </div>
+  </form>
+</div>
+
+<div class="card">
+  <h2>Lịch sử các lần chạy gần đây</h2>
+  {% if runs %}
+  <div class="table-wrapper">
+    <table>
+      <thead>
+        <tr>
+          <th>#</th>
+          <th>Thời gian</th>
+          <th>Động cơ</th>
+          <th>Độ tin cậy</th>
+          <th>Kết quả tóm tắt</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for run in runs %}
+        <tr>
+          <td>{{ run.id }}</td>
+          <td>{{ run.created_at.strftime("%d/%m/%Y %H:%M:%S") }}</td>
+          <td><span class="tag">{{ run.engine|upper }}</span></td>
+          <td>
+            {% if run.best_confidence is not none %}
+              {{ '%.2f'|format(run.best_confidence * 100) }}%
+            {% else %}
+              N/A
+            {% endif %}
+          </td>
+          <td style="max-width: 360px;">
+            {% if run.summary_text %}
+              {{ run.summary_text[:120] }}{% if run.summary_text|length > 120 %}…{% endif %}
+            {% else %}
+              (Chưa có văn bản)
+            {% endif %}
+          </td>
+          <td style="text-align: right;">
+            <a class="btn secondary" href="/runs/{{ run.id }}">Xem chi tiết</a>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% else %}
+  <p>Chưa có lần chạy nào. Hãy tải tài liệu để bắt đầu.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/app/templates/run_detail.html
+++ b/app/templates/run_detail.html
@@ -1,0 +1,90 @@
+{% extends "base.html" %}
+{% block title %}Chi tiết OCR #{{ run.id }}{% endblock %}
+{% block content %}
+<a href="/" class="btn secondary" style="margin-bottom: 1.5rem; display: inline-flex;">&larr; Quay lại danh sách</a>
+<div class="card">
+  <h2>Thông tin phiên OCR #{{ run.id }}</h2>
+  <div class="grid two">
+    <div>
+      <p><strong>Thời gian:</strong> {{ run.created_at.strftime("%d/%m/%Y %H:%M:%S") }}</p>
+      <p><strong>Động cơ:</strong> <span class="tag">{{ run.engine|upper }}</span></p>
+      <p>
+        <strong>Độ tin cậy cao nhất:</strong>
+        {% if run.best_confidence is not none %}
+          {{ '%.2f'|format(run.best_confidence * 100) }}%
+        {% else %}
+          N/A
+        {% endif %}
+      </p>
+    </div>
+    <div>
+      <p><strong>Tệp gốc:</strong> {{ run.original_file_path }}</p>
+      {% if run.converted_file_path %}
+      <p><strong>Tệp chuyển đổi:</strong> {{ run.converted_file_path }}</p>
+      {% endif %}
+    </div>
+  </div>
+  <div style="margin-top: 1.25rem;">
+    <h3>Văn bản tổng hợp</h3>
+    {% if run.summary_text %}
+    <pre>{{ run.summary_text }}</pre>
+    {% else %}
+    <p>Chưa có văn bản tổng hợp.</p>
+    {% endif %}
+  </div>
+</div>
+
+<div class="card">
+  <h2>Kết quả chi tiết</h2>
+  {% if results %}
+  <div class="grid two">
+    {% for result in results %}
+    <div style="border: 1px solid #e2e8f0; border-radius: 12px; padding: 1rem; background: #f8fafc;">
+      <h3 style="margin-top: 0;">{{ result.variant_label }}</h3>
+      <p style="margin: 0.25rem 0 0.75rem; color: #475569;">
+        {% if result.confidence is not none %}
+          Độ tin cậy: {{ '%.2f'|format(result.confidence * 100) }}%
+        {% else %}
+          Độ tin cậy: N/A
+        {% endif %}
+      </p>
+      <pre>{{ result.text }}</pre>
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <p>Chưa có kết quả OCR.</p>
+  {% endif %}
+</div>
+
+<div class="card">
+  <h2>Hình ảnh</h2>
+  <h3>Ảnh gốc</h3>
+  {% if source_images %}
+  <div class="grid two">
+    {% for image in source_images %}
+    <div>
+      <p><strong>{{ image.label }}</strong></p>
+      <img class="preview" src="/runs/{{ run.id }}/images/{{ image.id }}" alt="{{ image.label }}" />
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <p>Không có ảnh gốc.</p>
+  {% endif %}
+
+  <h3>Ảnh tiền xử lý</h3>
+  {% if preprocessed_images %}
+  <div class="grid two">
+    {% for image in preprocessed_images %}
+    <div>
+      <p><strong>{{ image.label }}</strong></p>
+      <img class="preview" src="/runs/{{ run.id }}/images/{{ image.id }}" alt="{{ image.label }}" />
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <p>Không có ảnh tiền xử lý.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ uvicorn[standard]==0.29.0
 sqlalchemy==2.0.29
 pydantic==1.10.14
 python-multipart==0.0.9
+Jinja2==3.1.3
 pillow==10.3.0
 pdf2image==1.17.0
 pytesseract==0.3.10


### PR DESCRIPTION
## Summary
- add helper functions and new API endpoints to expose available OCR engines and serve HTML pages
- implement a minimal management UI with templates for uploading documents and inspecting OCR runs
- document the new web interface entry point and include Jinja2 in the dependencies

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68dc94a0b45c8328af2002f420105b59