### PR TITLE
Configure OCR defaults for Vietnamese recognition

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     tesseract-ocr \
+    tesseract-ocr-vie \
     poppler-utils \
     libreoffice \
     fonts-dejavu-core \

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ requirements.txt    # Các phụ thuộc Python
 Dockerfile          # Docker hóa dịch vụ
 ```
 
+## Thiết lập ngôn ngữ OCR
+
+- Mặc định Tesseract chạy với cấu hình `vie+eng` để ưu tiên tiếng Việt nhưng vẫn giữ lại khả năng nhận diện tiếng Anh.
+- PaddleOCR được cấu hình với mã ngôn ngữ `vi`.
+- Có thể thay đổi thông qua biến môi trường `OCR_TESS_LANG` và `OCR_PADDLE_LANG` trước khi khởi động dịch vụ.
+- Khi chạy bằng Dockerfile đi kèm, gói `tesseract-ocr-vie` đã được cài đặt sẵn để hỗ trợ tiếng Việt có dấu.
+
 ## Chạy dịch vụ cục bộ
 
 ### Yêu cầu hệ thống

--- a/app/config.py
+++ b/app/config.py
@@ -10,8 +10,11 @@ class Settings(BaseSettings):
     data_dir: Path = Field(default=Path("storage"), env="OCR_DATA_DIR")
     database_url: str = Field(default="sqlite:///storage/ocr.db", env="OCR_DATABASE_URL")
     pdf_dpi: int = Field(default=300, env="OCR_PDF_DPI")
-    tess_lang: str = Field(default="eng", env="OCR_TESS_LANG")
-    paddle_lang: str = Field(default="en", env="OCR_PADDLE_LANG")
+    # Tesseract hỗ trợ truyền nhiều mã ngôn ngữ dạng "vie+eng" để nhận diện đa ngôn ngữ.
+    # Mặc định ưu tiên tiếng Việt nhưng vẫn bao phủ một phần tiếng Anh.
+    tess_lang: str = Field(default="vie+eng", env="OCR_TESS_LANG")
+    # PaddleOCR sử dụng mã "vi" cho tiếng Việt.
+    paddle_lang: str = Field(default="vi", env="OCR_PADDLE_LANG")
 
     class Config:
         env_file = ".env"


### PR DESCRIPTION
## Summary
- default the Tesseract engine to `vie+eng` and PaddleOCR to `vi` so Vietnamese text keeps accents
- add the `tesseract-ocr-vie` package to the Docker image to ship Vietnamese language data
- document how to configure OCR languages through environment variables in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dca1a108208328abcff7f618646d98