### PR TITLE
Enable per-run language selection for OCR engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Dịch vụ OCR mẫu được xây dựng cho hệ thống quản lý khoản v
 - **Quản lý lịch sử**: Lưu vào SQLite thông tin tệp gốc, tệp chuyển đổi, ảnh gốc, ảnh tiền xử lý, văn bản OCR kèm độ tin cậy.
 - **Lưu trữ tệp**: Toàn bộ tệp gốc, trang PDF, ảnh tiền xử lý được lưu trong thư mục `storage/` theo từng lần chạy.
 - **Docker hóa**: Dockerfile cài đặt đầy đủ phụ thuộc (Tesseract, LibreOffice, Poppler, PaddleOCR) để triển khai nhất quán.
+- **Tuỳ chọn ngôn ngữ theo từng lần chạy**: API và giao diện web cho phép nhập mã ngôn ngữ (`lang`) riêng cho từng động cơ, hỗ trợ PaddleOCR tiếng Việt (`vi`) cũng như các mã Tesseract (`vie+eng`, `eng`,...).
 
 ## Cấu trúc thư mục
 
@@ -36,6 +37,7 @@ Dockerfile          # Docker hóa dịch vụ
 - Mặc định Tesseract chạy với cấu hình `vie+eng` để ưu tiên tiếng Việt nhưng vẫn giữ lại khả năng nhận diện tiếng Anh.
 - PaddleOCR được cấu hình với mã ngôn ngữ `vi`.
 - Có thể thay đổi thông qua biến môi trường `OCR_TESS_LANG` và `OCR_PADDLE_LANG` trước khi khởi động dịch vụ.
+- Ngoài cấu hình mặc định, mỗi lần gọi API `/api/v1/ocr` đều có thể truyền thêm tham số `lang` (ví dụ `lang=vi` khi sử dụng PaddleOCR). Giao diện web cũng có ô nhập ngôn ngữ và tự động gợi ý giá trị mặc định theo từng động cơ.
 - Khi chạy bằng Dockerfile đi kèm, gói `tesseract-ocr-vie` đã được cài đặt sẵn để hỗ trợ tiếng Việt có dấu.
 
 ## Chạy dịch vụ cục bộ

--- a/app/models.py
+++ b/app/models.py
@@ -15,6 +15,7 @@ class OCRRun(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     engine: Mapped[str] = mapped_column(String(50))
+    language: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
     original_file_path: Mapped[str] = mapped_column(String)
     converted_file_path: Mapped[Optional[str]] = mapped_column(String, nullable=True)
     summary_text: Mapped[Optional[str]] = mapped_column(Text, nullable=True)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -33,6 +33,7 @@ class OCRRunSchema(BaseModel):
     id: int
     created_at: datetime
     engine: str
+    language: Optional[str]
     original_file_path: Path
     converted_file_path: Optional[Path]
     summary_text: Optional[str]

--- a/app/services/tesseract_engine.py
+++ b/app/services/tesseract_engine.py
@@ -15,7 +15,12 @@ class TesseractEngine:
     name = "tesseract"
 
     def __init__(self, lang: Optional[str] = None) -> None:
-        self.lang = lang or settings.tess_lang
+        initial = (lang or settings.tess_lang).strip()
+        self.lang = initial or settings.tess_lang
+
+    def set_language(self, lang: Optional[str]) -> None:
+        candidate = (lang or settings.tess_lang).strip()
+        self.lang = candidate or settings.tess_lang
 
     def run(self, image: Image.Image) -> OcrOutput:
         text = pytesseract.image_to_string(image, lang=self.lang)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -10,11 +10,33 @@
   <form action="/upload" method="post" enctype="multipart/form-data" class="grid two js-loading-form">
     <label>
       <span>Chọn động cơ OCR</span>
-      <select name="engine" style="width: 100%; padding: 0.5rem; border-radius: 8px; border: 1px solid #cbd5e1; margin-top: 0.5rem;">
+      <select
+        id="engine-select"
+        name="engine"
+        style="width: 100%; padding: 0.5rem; border-radius: 8px; border: 1px solid #cbd5e1; margin-top: 0.5rem;"
+      >
         {% for engine in engines %}
-        <option value="{{ engine }}" {% if engine == selected_engine %}selected{% endif %}>{{ engine|capitalize }}</option>
+        <option
+          value="{{ engine }}"
+          data-default-lang="{{ engine_default_langs.get(engine, '') }}"
+          {% if engine == selected_engine %}selected{% endif %}
+        >
+          {{ engine|capitalize }}
+        </option>
         {% endfor %}
       </select>
+    </label>
+    <label>
+      <span>Mã ngôn ngữ (lang)</span>
+      <input
+        id="lang-input"
+        type="text"
+        name="lang"
+        value="{{ selected_lang }}"
+        style="width: 100%; padding: 0.5rem; border-radius: 8px; border: 1px solid #cbd5e1; margin-top: 0.5rem;"
+        placeholder="Ví dụ: vie+eng hoặc vi"
+      />
+      <span class="form-note">Ví dụ: <code>vie+eng</code> cho Tesseract, <code>vi</code> cho PaddleOCR.</span>
     </label>
     <label>
       <span>Tài liệu đầu vào</span>
@@ -33,6 +55,42 @@
   </form>
 </div>
 
+<script>
+  document.addEventListener("DOMContentLoaded", function () {
+    var select = document.getElementById("engine-select");
+    var langInput = document.getElementById("lang-input");
+    if (!select || !langInput) {
+      return;
+    }
+    var defaults = {};
+    select.querySelectorAll("option").forEach(function (option) {
+      defaults[option.value] = option.dataset.defaultLang || "";
+    });
+    var previousDefault = defaults[select.value] || "";
+    if (!langInput.value.trim()) {
+      langInput.value = previousDefault;
+    }
+    updatePlaceholder(previousDefault);
+
+    select.addEventListener("change", function () {
+      var nextDefault = defaults[select.value] || "";
+      if (!langInput.value.trim() || langInput.value === previousDefault) {
+        langInput.value = nextDefault;
+      }
+      previousDefault = nextDefault;
+      updatePlaceholder(nextDefault);
+    });
+
+    function updatePlaceholder(defaultLang) {
+      if (defaultLang) {
+        langInput.placeholder = "Ví dụ: " + defaultLang;
+      } else {
+        langInput.placeholder = "Ví dụ: vie+eng hoặc vi";
+      }
+    }
+  });
+</script>
+
 <div class="card">
   <h2>Lịch sử các lần chạy gần đây</h2>
   {% if runs %}
@@ -43,6 +101,7 @@
           <th>#</th>
           <th>Thời gian</th>
           <th>Động cơ</th>
+          <th>Ngôn ngữ</th>
           <th>Độ tin cậy</th>
           <th>Kết quả tóm tắt</th>
           <th></th>
@@ -54,6 +113,13 @@
           <td>{{ run.id }}</td>
           <td>{{ run.created_at.strftime("%d/%m/%Y %H:%M:%S") }}</td>
           <td><span class="tag">{{ run.engine|upper }}</span></td>
+          <td>
+            {% if run.language %}
+              <code>{{ run.language }}</code>
+            {% else %}
+              Mặc định
+            {% endif %}
+          </td>
           <td>
             {% if run.best_confidence is not none %}
               {{ run.best_confidence|format_confidence }}

--- a/app/templates/run_detail.html
+++ b/app/templates/run_detail.html
@@ -9,6 +9,14 @@
       <p><strong>Thời gian:</strong> {{ run.created_at.strftime("%d/%m/%Y %H:%M:%S") }}</p>
       <p><strong>Động cơ:</strong> <span class="tag">{{ run.engine|upper }}</span></p>
       <p>
+        <strong>Ngôn ngữ:</strong>
+        {% if run.language %}
+          <code>{{ run.language }}</code>
+        {% else %}
+          Mặc định
+        {% endif %}
+      </p>
+      <p>
         <strong>Độ tin cậy cao nhất:</strong>
         {% if run.best_confidence is not none %}
           {{ run.best_confidence|format_confidence }}


### PR DESCRIPTION
## Summary
- add per-run language selection to the API/web form and persist the chosen value on OCR runs
- refresh PaddleOCR/Tesseract engines when the language changes and ensure the database schema exposes the language column
- surface the run language in the UI and document how to request Vietnamese recognition with PaddleOCR

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68dca944b278832882998a89f9e5c0c0