### PR TITLE
Improve Paddle OCR preprocessing for Vietnamese text

### DIFF
--- a/app/services/ocr_service.py
+++ b/app/services/ocr_service.py
@@ -103,7 +103,17 @@ class OCRService:
                 session.add(db_image)
                 session.flush()
 
-                variants = self.preprocessor.generate(image)
+                preferred_variants = None
+                if hasattr(engine, "preferred_variants"):
+                    preferred_callable = getattr(engine, "preferred_variants")
+                    if callable(preferred_callable):
+                        preferred_variants = preferred_callable()
+                    else:
+                        preferred_variants = preferred_callable  # pragma: no cover - defensive
+                variants = self.preprocessor.generate(
+                    image,
+                    allowed_labels=preferred_variants,
+                )
                 for order, (label, variant_image) in enumerate(variants):
                     variant_path = run_dir / "preprocessed" / f"{db_image.label}_{label}.png"
                     variant_path.parent.mkdir(parents=True, exist_ok=True)

--- a/app/services/paddle_engine.py
+++ b/app/services/paddle_engine.py
@@ -33,6 +33,17 @@ class PaddleOCREngine:
         # Khởi tạo lại PaddleOCR ở lần chạy kế tiếp để áp dụng ngôn ngữ mới.
         self._ocr = None
 
+    def preferred_variants(self) -> tuple[str, ...]:
+        """Các bước tiền xử lý phù hợp nhất cho PaddleOCR.
+
+        PaddleOCR hoạt động tốt nhất khi giữ nguyên chi tiết và màu sắc của
+        dấu tiếng Việt. Các bước làm nổi bật như ``threshold`` có xu hướng
+        làm mất dấu, dẫn đến kết quả sai lệch. Vì vậy chỉ sử dụng các biến thể
+        giữ nguyên thông tin quan trọng.
+        """
+
+        return ("original", "grayscale", "contrast")
+
     def run(self, image: Image.Image) -> OcrOutput:
         np_image = np.array(image.convert("RGB"))
         ocr = self._ensure_ocr()


### PR DESCRIPTION
## Summary
- allow the preprocessing pipeline to filter generated variants per OCR engine
- have the Paddle OCR engine prefer variants that preserve Vietnamese diacritics
- teach the OCR service to honor engine-specific preprocessing preferences

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68dcadda6cfc8328a79fd6bb62ed5fc9