### PR TITLE
Add TrOCR engine

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -15,6 +15,10 @@ class Settings(BaseSettings):
     tess_lang: str = Field(default="vie+eng", env="OCR_TESS_LANG")
     # PaddleOCR sử dụng mã "vi" cho tiếng Việt.
     paddle_lang: str = Field(default="vi", env="OCR_PADDLE_LANG")
+    # TrOCR sử dụng tên mô hình trên Hugging Face, ví dụ "microsoft/trocr-base-printed".
+    trocr_model_name: str = Field(
+        default="microsoft/trocr-base-printed", env="OCR_TROCR_MODEL"
+    )
 
     class Config:
         env_file = ".env"

--- a/app/services/ocr_service.py
+++ b/app/services/ocr_service.py
@@ -23,6 +23,7 @@ from .ocr_base import OCREngine
 from .paddle_engine import PaddleOCREngine
 from .preprocess import ImagePreprocessor
 from .tesseract_engine import TesseractEngine
+from .trocr_engine import TrOCREngine
 
 class OCRService:
     def __init__(self) -> None:
@@ -30,6 +31,7 @@ class OCRService:
         self._engine_factories: Dict[str, Callable[[Optional[str]], OCREngine]] = {
             "tesseract": lambda lang=None: TesseractEngine(lang=lang),
             "paddle": lambda lang=None: PaddleOCREngine(lang=lang),
+            "trocr": lambda _=None: TrOCREngine(),
         }
 
     def list_engines(self) -> List[str]:
@@ -50,6 +52,8 @@ class OCRService:
             return settings.tess_lang
         if name == "paddle":
             return settings.paddle_lang
+        if name == "trocr":
+            return None
         return None
 
     def process(self, file: UploadFile, engine_name: str, *, lang: Optional[str] = None) -> OCRRun:

--- a/app/services/trocr_engine.py
+++ b/app/services/trocr_engine.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+import torch
+from PIL import Image
+from transformers import TrOCRProcessor, VisionEncoderDecoderModel
+
+from ..config import settings
+from .ocr_base import OCREngine, OcrOutput
+
+
+logger = logging.getLogger(__name__)
+
+
+class TrOCREngine:
+    """OCR engine sử dụng mô hình ``microsoft/trocr`` từ Hugging Face."""
+
+    name = "trocr"
+
+    def __init__(self, model_name: Optional[str] = None, device: Optional[str] = None) -> None:
+        self.model_name = (model_name or settings.trocr_model_name).strip() or settings.trocr_model_name
+        self.device = torch.device(device or ("cuda" if torch.cuda.is_available() else "cpu"))
+        self._processor: TrOCRProcessor | None = None
+        self._model: VisionEncoderDecoderModel | None = None
+
+    def preferred_variants(self) -> tuple[str, ...]:
+        """Ưu tiên giữ nguyên chi tiết và độ tương phản tự nhiên."""
+
+        return ("original", "grayscale", "contrast")
+
+    def _ensure_components(self) -> tuple[TrOCRProcessor, VisionEncoderDecoderModel]:
+        if self._processor is None:
+            try:
+                self._processor = TrOCRProcessor.from_pretrained(self.model_name)
+            except OSError as exc:  # pragma: no cover - chỉ log lỗi tải model
+                logger.error("Không thể tải TrOCR processor %s: %s", self.model_name, exc)
+                raise
+        if self._model is None:
+            try:
+                model = VisionEncoderDecoderModel.from_pretrained(self.model_name)
+            except OSError as exc:  # pragma: no cover - chỉ log lỗi tải model
+                logger.error("Không thể tải TrOCR model %s: %s", self.model_name, exc)
+                raise
+            self._model = model.to(self.device)
+            self._model.eval()
+        return self._processor, self._model
+
+    def set_model(self, model_name: Optional[str]) -> None:
+        candidate = (model_name or settings.trocr_model_name).strip()
+        new_name = candidate or settings.trocr_model_name
+        if new_name == self.model_name and self._model is not None and self._processor is not None:
+            return
+        self.model_name = new_name
+        self._processor = None
+        self._model = None
+
+    def run(self, image: Image.Image) -> OcrOutput:
+        processor, model = self._ensure_components()
+        pixel_values = processor(images=image.convert("RGB"), return_tensors="pt").pixel_values.to(self.device)
+        with torch.no_grad():
+            generated = model.generate(
+                pixel_values,
+                output_scores=True,
+                return_dict_in_generate=True,
+            )
+        sequence = generated.sequences[0]
+        text = processor.batch_decode(sequence.unsqueeze(0), skip_special_tokens=True)[0].strip()
+        confidence = None
+        scores = generated.scores
+        if scores:
+            probabilities = []
+            for step_scores, token_id in zip(scores, sequence[1:]):  # bỏ token BOS
+                probs = step_scores.softmax(dim=-1)
+                probabilities.append(probs[token_id].item())
+            if probabilities:
+                confidence = float(sum(probabilities) / len(probabilities))
+        return OcrOutput(text=text, confidence=confidence)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ paddlepaddle==2.6.2
 paddleocr==2.7.0.3
 python-docx==1.1.0
 numpy==1.26.4
+torch==2.2.2
+transformers==4.39.3


### PR DESCRIPTION
## Summary
- add a Hugging Face TrOCR engine with lazy model loading and confidence aggregation
- expose configuration for selecting the TrOCR model and register the engine with the OCR service
- document the new engine and add the required dependencies

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68dcdc9043e483289c4610f89d5b2fe9