### PR TITLE
Fix TrOCR confidence computation indexing

### DIFF
--- a/app/services/trocr_engine.py
+++ b/app/services/trocr_engine.py
@@ -73,7 +73,11 @@ class TrOCREngine:
             probabilities = []
             for step_scores, token_id in zip(scores, sequence[1:]):  # bỏ token BOS
                 probs = step_scores.softmax(dim=-1)
-                probabilities.append(probs[token_id].item())
+                token_index = int(token_id)
+                if probs.dim() == 2:
+                    probabilities.append(probs[0, token_index].item())
+                else:
+                    probabilities.append(probs[token_index].item())
             if probabilities:
                 confidence = float(sum(probabilities) / len(probabilities))
         return OcrOutput(text=text, confidence=confidence)


### PR DESCRIPTION
## Summary
- fix the TrOCR confidence calculation by indexing probability tensors using the batch dimension
- ensure the code works with both batched and unbatched score tensors to avoid IndexError on uploads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dcebfe71b4832886980cfb3c9d3ad0