### PR TITLE
Ensure TrOCR tokenizer tokens cover padding and start

### DIFF
--- a/app/services/trocr_engine.py
+++ b/app/services/trocr_engine.py
@@ -45,7 +45,47 @@ class TrOCREngine:
                 raise
             self._model = model.to(self.device)
             self._model.eval()
+            self._ensure_generation_tokens()
         return self._processor, self._model
+
+    def _ensure_generation_tokens(self) -> None:
+        """Bổ sung các mã đặc biệt cần thiết cho quá trình sinh chuỗi."""
+
+        if self._processor is None or self._model is None:  # pragma: no cover - defensive
+            return
+
+        tokenizer = self._processor.tokenizer
+        generation_config = self._model.generation_config
+
+        eos_token_id = getattr(tokenizer, "eos_token_id", None)
+        pad_token_id = getattr(tokenizer, "pad_token_id", None)
+        if pad_token_id is None and eos_token_id is not None:
+            tokenizer.pad_token = tokenizer.eos_token
+            pad_token_id = eos_token_id
+
+        if pad_token_id is not None:
+            generation_config.pad_token_id = pad_token_id
+            self._model.config.pad_token_id = pad_token_id
+
+        bos_token_id = getattr(tokenizer, "bos_token_id", None)
+        cls_token_id = getattr(tokenizer, "cls_token_id", None)
+        start_token_id = bos_token_id if bos_token_id is not None else cls_token_id
+        if start_token_id is None:
+            start_token_id = pad_token_id
+        if start_token_id is None and eos_token_id is not None:
+            start_token_id = eos_token_id
+
+        if start_token_id is not None:
+            generation_config.decoder_start_token_id = start_token_id
+            self._model.config.decoder_start_token_id = start_token_id
+
+        if bos_token_id is not None:
+            generation_config.bos_token_id = bos_token_id
+            self._model.config.bos_token_id = bos_token_id
+
+        if eos_token_id is not None:
+            generation_config.eos_token_id = eos_token_id
+            self._model.config.eos_token_id = eos_token_id
 
     def set_model(self, model_name: Optional[str]) -> None:
         candidate = (model_name or settings.trocr_model_name).strip()


### PR DESCRIPTION
## Summary
- set the TrOCR tokenizer pad token to EOS when missing and propagate it to the model config
- ensure decoder start, BOS, and EOS token IDs are always populated on the model generation config

## Testing
- python -m compileall app/services/trocr_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68dcf04a01cc8328ad80cf268cbe4ecf