### PR TITLE
Add offline TrOCR model configuration and clearer errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,14 @@ Dockerfile          # Docker hóa dịch vụ
 
 - Mặc định Tesseract chạy với cấu hình `vie+eng` để ưu tiên tiếng Việt nhưng vẫn giữ lại khả năng nhận diện tiếng Anh.
 - PaddleOCR được cấu hình với mã ngôn ngữ `vi`.
-- TrOCR sử dụng model `microsoft/trocr-base-printed` phù hợp cho tài liệu in.
+- TrOCR sử dụng model `microsoft/trocr-base-printed` phù hợp cho tài liệu in. Nếu môi trường không thể truy
+  cập internet, hãy tải sẵn model từ Hugging Face và đặt biến môi trường `OCR_TROCR_MODEL_PATH` trỏ tới thư
+  mục đã giải nén (chứa `config.json`, `pytorch_model.bin`,...). Khi đó dịch vụ sẽ ưu tiên nạp model từ thư
+  mục cục bộ thay vì cố gắng tải qua mạng.
 - Bộ từ điển tiếng Việt mặc định của PaddleOCR dựa trên bảng chữ cái Latin nên thiếu nhiều ký tự có dấu (`ă`, `â`, `ơ`, `ư`,...).
   Dự án bổ sung tệp `app/resources/paddle_vi_dict.txt` để nạp vào PaddleOCR. Do mô hình Latin chỉ hỗ trợ tối đa 185 ký tự, tệp đã được tinh gọn về đúng kích thước này bằng cách thay thế các ký tự ít dùng bằng bảng chữ cái tiếng Việt mở rộng. Nếu vượt quá giới hạn, Paddle sẽ giải mã sai (xuất hiện ký tự `Ă` giữa các từ), vì vậy dịch vụ sẽ kiểm tra kích thước tệp và bỏ qua nếu không hợp lệ.
-- Có thể thay đổi thông qua biến môi trường `OCR_TESS_LANG`, `OCR_PADDLE_LANG` và `OCR_TROCR_MODEL` trước khi khởi động dịch vụ.
+- Có thể thay đổi thông qua biến môi trường `OCR_TESS_LANG`, `OCR_PADDLE_LANG`, `OCR_TROCR_MODEL` và
+  `OCR_TROCR_MODEL_PATH` trước khi khởi động dịch vụ.
 - Ngoài cấu hình mặc định, mỗi lần gọi API `/api/v1/ocr` đều có thể truyền thêm tham số `lang` (ví dụ `lang=vi` khi sử dụng PaddleOCR). Giao diện web cũng có ô nhập ngôn ngữ và tự động gợi ý giá trị mặc định theo từng động cơ.
 - Khi chạy bằng Dockerfile đi kèm, gói `tesseract-ocr-vie` đã được cài đặt sẵn để hỗ trợ tiếng Việt có dấu.
 

--- a/app/config.py
+++ b/app/config.py
@@ -19,6 +19,8 @@ class Settings(BaseSettings):
     trocr_model_name: str = Field(
         default="microsoft/trocr-base-printed", env="OCR_TROCR_MODEL"
     )
+    # Có thể trỏ đến thư mục mô hình đã tải sẵn (offline).
+    trocr_model_path: Path | None = Field(default=None, env="OCR_TROCR_MODEL_PATH")
 
     class Config:
         env_file = ".env"


### PR DESCRIPTION
## Summary
- allow configuring TrOCR with a pre-downloaded model directory via `OCR_TROCR_MODEL_PATH`
- improve the TrOCR engine to load from the local directory and raise actionable errors when downloads fail
- document the offline model option in the README

## Testing
- python -m compileall OCR/app
- python -m compileall OCR/app/services/trocr_engine.py

------
https://chatgpt.com/codex/tasks/task_e_68dcf59dc9b48328b529a8c7eac6e286