### PR TITLE
Fix pip install failure when building image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
+ENV TMPDIR=/var/tmp
+RUN mkdir -p "$TMPDIR" && chmod 1777 "$TMPDIR"
+
 WORKDIR /app
 
 COPY requirements.txt ./


### PR DESCRIPTION
## Summary
- ensure the container has a writable temporary directory for pip operations

## Testing
- not run (docker unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68de0364939c8328a6e86ca6416cda61